### PR TITLE
Fix bug in polynomial evaluation

### DIFF
--- a/core/daceeval.c
+++ b/core/daceeval.c
@@ -461,11 +461,21 @@ void daceEvalTree(const DACEDA *das[], const unsigned int count, double ac[], un
         else
         {
             // step back
-            p[stack[sp]] = 0;
+            p[stack[sp]]--;
             sp--;
         }
     }
 
+#ifdef WITH_DEBUG
+    // check if all monomials were properly encoded (should never fail except if above algorithm is implemented incorrectly)
+    for(unsigned int i = 0; i < DACECom.nmmax; i++)
+        if(nc[i] != 3 && nc[i] != 0)
+        {
+            daceSetError(__func__, DACE_PANIC, 8);
+            exit(1);
+        }
+#endif
+    
 #if DACE_MEMORY_MODEL != DACE_MEMORY_STATIC
     dacefree(nc);
     dacefree(p);

--- a/core/include/dace/daceerror.h
+++ b/core/include/dace/daceerror.h
@@ -39,7 +39,7 @@ typedef struct {
 
 
 DACE_API static const errstrings DACEerr[] = {
-    {   0, "Unknown DACE error. Contact Dinamica SRL for filing a bug report."},
+    {   0, "Unknown DACE error. Contact DACE developers for filing a bug report."},
     {1001, "Dynamic memory allocation failure"},
     {1002, "Out of memory"},
     {1003, "DACE has not been initialized"},
@@ -47,6 +47,7 @@ DACE_API static const errstrings DACEerr[] = {
     {1005, "Incorrect number of monomials"},
     {1006, "Incorrect DA coding arrays"},
     {1007, "Requested length too long"},
+    {1008, "Error in monomial evaluation tree construction"},
     {   8, ""},
     {   9, ""},
     {  10, ""},


### PR DESCRIPTION
Fix a nasty bug in the evaluation tree calculation code that leads to wrong results under some circumstances. Also introduces an automated check in the code to ensure all monomials have been handled properly (only enabled in debug builds).

This closes issue #13 