### PR TITLE
Fix CMake package

### DIFF
--- a/Tutorials/Tutorial1/CMakeLists.txt
+++ b/Tutorials/Tutorial1/CMakeLists.txt
@@ -10,12 +10,22 @@
 #   dace::dace_s (the static DACE library)
 # Make sure to link your executable with one of those and include the correct
 # header (<dace/dace.h> or <dace/dace_s.h>) in the code.
+#
+# On Windows only, the dace.dll dynamics library is typically expected to be
+# located in the same directory as the executable using it. You can use a
+# command such as the file(COPY ...) below to automatically copy the dace.dll
+# from the DACE package next to your executables.
 
 cmake_minimum_required (VERSION 2.8.4)
 
 project(Examples1 CXX)
 
 find_package(dace 2.0.0 REQUIRED)
+
+if(WIN32)
+    get_target_property(DACEDLL dace::dace LOCATION)
+    file(COPY "${DACEDLL}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+endif(WIN32)
 
 add_executable(Example1 Example1.cpp)
 target_link_libraries(Example1 PUBLIC dace::dace)

--- a/Tutorials/Tutorial2/CMakeLists.txt
+++ b/Tutorials/Tutorial2/CMakeLists.txt
@@ -10,12 +10,22 @@
 #   dace::dace_s (the static DACE library)
 # Make sure to link your executable with one of those and include the correct
 # header (<dace/dace.h> or <dace/dace_s.h>) in the code.
+#
+# On Windows only, the dace.dll dynamics library is typically expected to be
+# located in the same directory as the executable using it. You can use a
+# command such as the file(COPY ...) below to automatically copy the dace.dll
+# from the DACE package next to your executables.
 
 cmake_minimum_required (VERSION 2.8.4)
 
 project(Examples2 CXX)
 
 find_package(dace 2.0.0 REQUIRED)
+
+if(WIN32)
+    get_target_property(DACEDLL dace::dace LOCATION)
+    file(COPY "${DACEDLL}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+endif(WIN32)
 
 add_executable(1Basics-Ex 1Basics-Ex.cpp)
 target_link_libraries(1Basics-Ex PUBLIC dace::dace)

--- a/interfaces/cxx/CMakeLists.txt
+++ b/interfaces/cxx/CMakeLists.txt
@@ -35,6 +35,9 @@ set_property(TARGET dace_s PROPERTY VERSION "${DACE_MAJOR_VERSION}.${DACE_MINOR_
 set_property(TARGET dace_s PROPERTY INTERFACE_dace_s_MAJOR_VERSION ${DACE_MAJOR_VERSION})
 set_property(TARGET dace_s APPEND PROPERTY COMPATIBLE_INTERFACE_STRING dace_s_MAJOR_VERSION)
 
+# explicitly set required minimum C++ standard so it carries through to exported targets and consumers
+set_property(TARGET dace PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_11)
+set_property(TARGET dace_s PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_11)
 
 install(TARGETS dace EXPORT dace
         LIBRARY DESTINATION lib COMPONENT libraries


### PR DESCRIPTION
- pass C++ language standard requirement (min C++ 11) to consumers
- add small boiler plate code to the Tutorials to show how to automatically copy dace.dll to the output directory on Windows