### PR TITLE
fix issue dacelib#32

### DIFF
--- a/interfaces/cxx/include/dace/AlgebraicVector_t.h
+++ b/interfaces/cxx/include/dace/AlgebraicVector_t.h
@@ -908,7 +908,7 @@ template<typename U> std::ostream& operator<<(std::ostream &out, const Algebraic
 
     out << "[[[ " << size << " vector" << std::endl;
     for(size_t i=0; i<size;i++){
-        out << obj[i] << std::endl;}
+        out << obj[i]; }
     out << "]]]" << std::endl;
 
     return out;


### PR DESCRIPTION
modified ofstream << operator to avoid adding newline between elements of an AlgebraicVector. This solves the issue #32 with the >> operator which should be now fully compatible (Tested on Linux and Windows)  