### PR TITLE
Default DA epsilon to 0.0 and stop filtering NaNs and INFs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.4)
+cmake_minimum_required (VERSION 3.0.0)
 include(CMakeDependentOption)
 
 # since MacOS 10.14 (XCode 10.0), default includes are no longer installed to /usr/include or /usr/local/include

--- a/core/daceaux.c
+++ b/core/daceaux.c
@@ -345,32 +345,25 @@ void dacePack(double cc[], DACEDA *inc)
     if(LIKELY(DACECom.lfi == 0))
 #endif
     {
+        // provide loop without error checking for big enough target DA
         if(LIKELY(ilmc >= DACECom.nmmax))
         {
             for(unsigned int i = 0; i < DACECom.nmmax; i++)
             {
-//#define OPTIMIZE  // not clear if this actually helps in any way
-#ifndef OPTIMIZE
-                if(fabs(cc[i]) >= DACECom_t.eps)  //  && (DACECom.ieo[i] <= DACECom_t.nocut) is avoided for performance
+                if(!(fabs(cc[i]) <= DACECom_t.eps))  //  && (DACECom.ieo[i] <= DACECom_t.nocut) is avoided for performance
                 {
                     ic->ii = i;
                     ic->cc = cc[i];
                     ic++;
                 }
                 cc[i] = 0.0;
-#else
-                ic->ii = i;
-                ic->cc = cc[i];
-                ic += (fabs(cc[i]) >= DACECom_t.eps);
-                cc[i] = 0.0;
-#endif
             }
         }
         else
         {
             for(unsigned int i = 0; i < DACECom.nmmax; i++)
             {
-                if(fabs(cc[i]) >= DACECom_t.eps && DACECom.ieo[i] <= DACECom_t.nocut)
+                if(!(fabs(cc[i]) <= DACECom_t.eps) && DACECom.ieo[i] <= DACECom_t.nocut)     // here we remove also cut orders to save as much space as possible
                 {
                     if(ic >= ipoc+ilmc)
                     {
@@ -391,7 +384,7 @@ void dacePack(double cc[], DACEDA *inc)
     {
         for(unsigned int i = 0; i < DACECom.nmmax; i++)
         {
-            if((DACECom.ifi[i] != 0) && (fabs(cc[i]) >= DACECom_t.eps) && (DACECom.ieo[i] <= DACECom_t.nocut))
+            if((DACECom.ifi[i] != 0) && !(fabs(cc[i]) <= DACECom_t.eps) && (DACECom.ieo[i] <= DACECom_t.nocut))
             {
                 if(ic >= ipoc+ilmc)
                 {

--- a/core/dacebasic.c
+++ b/core/dacebasic.c
@@ -65,7 +65,7 @@ void daceCreateVariable(DACEDA *ina, const unsigned int i, const double ckon)
         return;
     }
 
-    if(fabs(ckon) < DACECom_t.eps)
+    if(fabs(ckon) <= DACECom_t.eps)
     {
         return;
     }
@@ -117,15 +117,15 @@ void daceCreateMonomial(DACEDA *ina, const unsigned int jj[], const double ckon)
         return;
     }
 
-    if(fabs(ckon) >= DACECom_t.eps)
+    if(fabs(ckon) <= DACECom_t.eps)
+    {
+        daceSetLength(ina, 0);
+    }
+    else
     {
         ipoa->ii = daceEncode(jj);
         ipoa->cc = ckon;
         daceSetLength(ina, 1);
-    }
-    else
-    {
-        daceSetLength(ina, 0);
     }
 }
 
@@ -390,7 +390,7 @@ void daceSetCoefficient0(DACEDA *ina, const unsigned int ic, const double cjj)
     if(insert)
     {
         // insert a new monomial before the i-th monomial
-        if(fabs(cjj) < DACECom_t.eps) return;
+        if(fabs(cjj) <= DACECom_t.eps) return;
 
         if(illa+1 > ilma)
         {
@@ -410,16 +410,16 @@ void daceSetCoefficient0(DACEDA *ina, const unsigned int ic, const double cjj)
     else
     {
         // replace the i-th monomial
-        if(fabs(cjj) < DACECom_t.eps)
+        if(!(fabs(cjj) <= DACECom_t.eps))
+        {
+            i->cc = cjj;
+        }
+        else
         {
             //memmove(i, i+1, (ipoa+illa - i-1)*sizeof(monomial));
             for(monomial *ii = i; ii < ipoa+(illa-1); ii++)
                 *ii = *(ii+1);
             daceSetLength(ina, illa-1);
-        }
-        else
-        {
-            i->cc = cjj;
         }
     }
 }
@@ -506,7 +506,7 @@ void daceCopyFiltering(const DACEDA *ina, DACEDA *inb)
     {
         for(monomial *ia = ipoa; ia < ipoa+illa; ia++)
         {
-            if(fabs(ia->cc) < DACECom_t.eps || DACECom.ieo[ia->ii] > DACECom_t.nocut)
+            if(fabs(ia->cc) <= DACECom_t.eps || DACECom.ieo[ia->ii] > DACECom_t.nocut)
                 continue;
             *ib = *ia;
             ib++;
@@ -516,7 +516,7 @@ void daceCopyFiltering(const DACEDA *ina, DACEDA *inb)
     {
         for(monomial *ia = ipoa; ia < ipoa+illa; ia++)
         {
-            if(fabs(ia->cc) < DACECom_t.eps || DACECom.ieo[ia->ii] > DACECom_t.nocut)
+            if(fabs(ia->cc) <= DACECom_t.eps || DACECom.ieo[ia->ii] > DACECom_t.nocut)
                 continue;
             if(ib >= ipob+ilmb)
             {
@@ -568,8 +568,8 @@ void daceTrim(const DACEDA *ina, const unsigned int imin, const unsigned int ima
 }
 
 /*! Copy monomials from a DA object ina to DA object inb if the same monomial
-    is non-zero in DA vector inc, while filtering out terms below the current
-    threshold
+    is non-zero in DA object inc, while filtering out terms below the current
+    cutoff
    \param[in] ina Pointer to DA object to filter
    \param[in] inb Pointer to DA object to store the filtered result in
    \param[in] inc Pointer to DA object providing the filter template
@@ -595,7 +595,7 @@ void daceFilter(const DACEDA *ina, DACEDA *inb, const DACEDA *inc)
                 ic++;
             if(ic >= ipoc+illc) break;
 
-            if(ia->ii < ic->ii || fabs(ia->cc) < DACECom_t.eps || DACECom.ieo[ia->ii] > DACECom_t.nocut)
+            if(ia->ii < ic->ii || fabs(ia->cc) <= DACECom_t.eps || DACECom.ieo[ia->ii] > DACECom_t.nocut)
                 continue;
 
             *ib = *ia;
@@ -611,7 +611,7 @@ void daceFilter(const DACEDA *ina, DACEDA *inb, const DACEDA *inc)
                 ic++;
             if(ic >= ipoc+illc) break;
 
-            if(ia->ii < ic->ii || fabs(ia->cc) < DACECom_t.eps || DACECom.ieo[ia->ii] > DACECom_t.nocut)
+            if(ia->ii < ic->ii || fabs(ia->cc) <= DACECom_t.eps || DACECom.ieo[ia->ii] > DACECom_t.nocut)
                 continue;
 
             if(ib >= ipob+ilmb)

--- a/core/dacemath.c
+++ b/core/dacemath.c
@@ -328,12 +328,12 @@ void daceMultiplyDouble(const DACEDA *ina, const double ckon, DACEDA *inb)
                 continue;
 
             const double c = ia->cc*ckon;
-            if(fabs(c) < DACECom_t.eps)
-                continue;
-
-            ib->cc = c;
-            ib->ii = ia->ii;
-            ib++;
+            if(!(fabs(c) <= DACECom_t.eps))
+            {
+                ib->cc = c;
+                ib->ii = ia->ii;
+                ib++;
+            }
         }
     }
     else
@@ -345,17 +345,17 @@ void daceMultiplyDouble(const DACEDA *ina, const double ckon, DACEDA *inb)
                 continue;
 
             const double c = ia->cc*ckon;
-            if(fabs(c) < DACECom_t.eps)
-                continue;
-
-            if(ib >= ibmax)
+            if(!(fabs(c) <= DACECom_t.eps))
             {
-                daceSetError(__func__, DACE_ERROR, 21);
-                break;
+                if(ib >= ibmax)
+                {
+                    daceSetError(__func__, DACE_ERROR, 21);
+                    break;
+                }
+                ib->cc = c;
+                ib->ii = ia->ii;
+                ib++;
             }
-            ib->cc = c;
-            ib->ii = ia->ii;
-            ib++;
         }
     }
 
@@ -608,16 +608,17 @@ void daceIntegrate(const unsigned int iint, const DACEDA *ina, DACEDA *inc)
             const unsigned int ic2 = DACECom.ie2[i->ii];
             const unsigned int ipow = (ic2/idiv)%ibase;
             const double ccc = i->cc/(ipow+1);
-            if(fabs(ccc) < DACECom_t.eps)
-                continue;
-            if(ic >= icmax)
+            if(!(fabs(ccc) <= DACECom_t.eps))
             {
-                daceSetError(__func__, DACE_ERROR, 21);
-                break;
+                if(ic >= icmax)
+                {
+                    daceSetError(__func__, DACE_ERROR, 21);
+                    break;
+                }
+                ic->ii = DACECom.ia1[ic1] + DACECom.ia2[ic2+idiv];
+                ic->cc = ccc;
+                ic = ic+1;
             }
-            ic->ii = DACECom.ia1[ic1] + DACECom.ia2[ic2+idiv];
-            ic->cc = ccc;
-            ic = ic+1;
         }
     }
     else
@@ -630,16 +631,17 @@ void daceIntegrate(const unsigned int iint, const DACEDA *ina, DACEDA *inc)
             const unsigned int ic2 = DACECom.ie2[i->ii];
             const unsigned int ipow = (ic1/idiv)%ibase;
             const double ccc = i->cc/(ipow+1);
-            if(fabs(ccc) < DACECom_t.eps)
-                continue;
-            if(ic >= icmax)
+            if(!(fabs(ccc) <= DACECom_t.eps))
             {
-                daceSetError(__func__, DACE_ERROR, 21);
-                break;
+                if(ic >= icmax)
+                {
+                    daceSetError(__func__, DACE_ERROR, 21);
+                    break;
+                }
+                ic->ii = DACECom.ia1[ic1+idiv] + DACECom.ia2[ic2];
+                ic->cc = ccc;
+                ic = ic+1;
             }
-            ic->ii = DACECom.ia1[ic1+idiv] + DACECom.ia2[ic2];
-            ic->cc = ccc;
-            ic = ic+1;
         }
     }
 
@@ -2044,7 +2046,7 @@ void daceWeightedSum(const DACEDA *ina, const double afac, const DACEDA *inb, co
                 if(DACECom.ieo[ja] <= DACECom_t.nocut)
                 {
                     const double ccc = ia->cc*afac + ib->cc*bfac;
-                    if(fabs(ccc) >= DACECom_t.eps)
+                    if(!(fabs(ccc) <= DACECom_t.eps))
                     {
                         if(ic >= icmax)
                         {
@@ -2068,7 +2070,7 @@ void daceWeightedSum(const DACEDA *ina, const double afac, const DACEDA *inb, co
                 if(DACECom.ieo[ja] <= DACECom_t.nocut)
                 {
                     const double ccc = ia->cc*afac;
-                    if(fabs(ccc) >= DACECom_t.eps)
+                    if(!(fabs(ccc) <= DACECom_t.eps))
                     {
                         if(ic >= icmax)
                         {
@@ -2091,7 +2093,7 @@ void daceWeightedSum(const DACEDA *ina, const double afac, const DACEDA *inb, co
                 if(DACECom.ieo[jb] <= DACECom_t.nocut)
                 {
                     const double ccc = ib->cc*bfac;
-                    if(fabs(ccc) >= DACECom_t.eps)
+                    if(!(fabs(ccc) <= DACECom_t.eps))
                     {
                         if(ic >= icmax)
                         {
@@ -2132,7 +2134,7 @@ void daceWeightedSum(const DACEDA *ina, const double afac, const DACEDA *inb, co
         if(DACECom.ieo[is->ii] <= DACECom_t.nocut)
         {
             const double ccc = is->cc*fac;
-            if(fabs(ccc) >= DACECom_t.eps)
+            if(!(fabs(ccc) <= DACECom_t.eps))
             {
                 if(ic >= icmax)
                 {

--- a/core/dacemath.c
+++ b/core/dacemath.c
@@ -1343,11 +1343,25 @@ void daceHyperbolicCosine(const DACEDA *ina, DACEDA *inc)
 void daceHyperbolicTangent(const DACEDA *ina, DACEDA *inc)
 {
     DACEDA itemp;
+    const double a0 = daceGetConstant(ina);
 
     daceAllocateDA(&itemp, 0);
-    daceHyperbolicSine(ina, &itemp);
-    daceHyperbolicCosine(ina, inc);
-    daceDivide(&itemp, inc, inc);
+    if(a0 > 0.0)
+    {
+        daceMultiplyDouble(ina, -2.0, &itemp);
+        daceExponential(&itemp, &itemp);
+        daceAddDouble(&itemp, 1.0, inc);
+        daceDoubleSubtract(&itemp, 1.0, &itemp);
+        daceDivide(&itemp, inc, inc);
+    }
+    else
+    {
+        daceMultiplyDouble(ina, 2.0, &itemp);
+        daceExponential(&itemp, &itemp);
+        daceAddDouble(&itemp, 1.0, inc);
+        daceAddDouble(&itemp, -1.0, &itemp);
+        daceDivide(&itemp, inc, inc);
+    }
     daceFreeDA(&itemp);
 }
 

--- a/core/dacenorm.c
+++ b/core/dacenorm.c
@@ -229,7 +229,7 @@ void daceEstimate(const DACEDA *ina, const unsigned int ivar, const unsigned int
     double xtx[2][2] = {{0.0}, {0.0}};
     for(unsigned int i = 1; i <= DACECom.nomax; i++)
     {
-        if(onorm[i] > DACECom_t.eps)
+        if(!(onorm[i] <= DACECom_t.eps))
         {
             xtx[0][0] += i*i;
             xtx[0][1] -= i;


### PR DESCRIPTION
Addressing partially #37 by defaulting to 0.0 for the DA eps cutoff.
Also the filtering logic has been carefully rewritten to always compare coefficients in a way to never exclude inf or nan values from a DA. This is done by always checking for `fabs(c) <= DACom_t.eps`, which is true if c should be discarded, and negating this expression when needed.