### PR TITLE
Remove duplicated error ID

### DIFF
--- a/core/include/dace/daceerror.h
+++ b/core/include/dace/daceerror.h
@@ -48,7 +48,6 @@ DACE_API const errstrings DACEerr[] = {
     {1006, "Incorrect DA coding arrays"},
     {1007, "Requested length too long"},
     {1008, "Error in monomial evaluation tree construction"},
-    {   8, ""},
     {   9, ""},
     {  10, ""},
     { 911, "Order and/or variable too large"},


### PR DESCRIPTION
The list of error IDs contained both `1008` and `8`, causing all errors with ID grater than 8 to display an incorrect message. This PR removes the `8` which is not used.