### PR TITLE
Fix bug when reading zero DA from ascii file

### DIFF
--- a/interfaces/cxx/DA.cpp
+++ b/interfaces/cxx/DA.cpp
@@ -1806,12 +1806,29 @@ std::istream& operator>>(std::istream &in, DA &da){
             }
         }
 
-        // read the istream until end string is found and put each line in the string vector (end condition taken from daceio.c)
-        for(getline(in, line); in.good() && (line.compare(4, 31, endstr, 0, 31) != 0); getline(in, line))
-            strs.push_back(line);
+        if (!strs.empty())
+        {
+            if(!strs.back().empty())
+            {
+                // check that last line is not the terminator line and in case remove it
+                if(strs.back().compare(4, 31, endstr, 0, 31) == 0)
+                {
+                    strs.pop_back();
 
-        // convert string vector to DA
-        da = DA::fromString(strs);
+                }
+                else
+                {
+                    // read the istream until end string is found and put each line in the string vector (end condition taken from daceio.c)
+                    for(getline(in, line); in.good() && (line.compare(4, 31, endstr, 0, 31) != 0); getline(in, line))
+                    strs.push_back(line);
+                }
+            }
+            // convert string vector to DA
+            da = DA::fromString(strs);
+        }
+        
+
+        
     }
 
     return in;


### PR DESCRIPTION
This should address issue #54. The problem is that when reading the ifstream the first string is used to initialize a storeDA, which fetch a string of size headersize, meant to tackle with the binary format. Usually the actual line in the file is longer than headersize, and it is necessary to fetch the remaining characters of the line. However, in the case of a zero DA the actual line is shorter than headersize and the code fetch also the terminator line. With the proposed modification a check that the last line fetched is the terminator line is introduced.