### PR TITLE
Fix MacOS rpath handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,9 @@ if(WIN32)
 elseif(APPLE)
   cmake_policy(SET CMP0042 NEW)
   cmake_policy(SET CMP0068 NEW)
-  set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-  set(CMAKE_INSTALL_NAME_DIR "@loader_path")
+  # build libraries use full hard-coded binary path, install libraries replace it by @rpath
+  set(CMAKE_MACOSX_RPATH OFF)
+  set(CMAKE_INSTALL_NAME_DIR "@rpath")
 endif(WIN32)
 
 


### PR DESCRIPTION
To allow both the traditional installation of DACE libraries in system directories and the full in-tree build using FetchContent on MacOSX the logic for RPATH handling is now this:
* build tree: all libraries and binaries are built with full absolute RPATH pointing to the binary tree. This allows any executable linking the dace target to "just run" in place. They are, however, not relocatable
* install tree: all absolute paths are replaced with @rpath to allow relocation and installation into system directories. This allows using find_package() to link DACE programs that are location independent