### PR TITLE
abs() rework and odeint compatibility headers

### DIFF
--- a/core/dacecompat.c
+++ b/core/dacecompat.c
@@ -63,14 +63,16 @@ void dacepek(const DACEDA *ina, const unsigned int jj[], double *cjj)
 }
 
 /*! Compute absolute value of a DA object.
+    Same as daceNorm(ina, 0).
    \param[in] ina Pointer to DA object to take absolute value of
    \param[out] anorm Pointer where to store the absolute value
-   \deprecated Has been replaced by daceAbsoluteValue()
-   \sa daceAbsoluteValue()
+   \deprecated Has been replaced by daceNorm() and daceAbsolute()
+   \sa daceNorm()
+   \sa daceAbsolute()
 */
 void daceabs(const DACEDA *ina, double *anorm)
 {
-    *anorm = daceAbsoluteValue(ina);
+    *anorm = daceNorm(ina, 0);
 }
 
 /*! Compute absolute value of a DA object.

--- a/core/dacemath.c
+++ b/core/dacemath.c
@@ -328,7 +328,7 @@ void daceMultiplyDouble(const DACEDA *ina, const double ckon, DACEDA *inb)
                 continue;
 
             const double c = ia->cc*ckon;
-            if(!(fabs(c) <= DACECom_t.eps))
+            if(LIKELY(!(fabs(c) <= DACECom_t.eps)))
             {
                 ib->cc = c;
                 ib->ii = ia->ii;
@@ -345,7 +345,7 @@ void daceMultiplyDouble(const DACEDA *ina, const double ckon, DACEDA *inb)
                 continue;
 
             const double c = ia->cc*ckon;
-            if(!(fabs(c) <= DACECom_t.eps))
+            if(LIKELY(!(fabs(c) <= DACECom_t.eps)))
             {
                 if(UNLIKELY(ib >= ibmax))
                 {
@@ -653,6 +653,22 @@ void daceIntegrate(const unsigned int iint, const DACEDA *ina, DACEDA *inc)
  *     DACE intrinsic function routines
  *********************************************************************************/
 
+/*! Absolute value of a DA object.
+    Returns either the DA or the negative of the DA based on the constant part.
+   \param[in] ina Pointer to the DA object to operate on
+   \param[out] inc Pointer to the DA object to store the result in
+   \note This routine is aliasing safe, i.e. inc can be the same as ina.
+   \sa daceAbsoluteValue
+   \sa daceNorm
+ */
+void daceAbsolute(const DACEDA *ina, DACEDA *inc)
+{
+    daceCopy(ina, inc);
+    const double a0 = daceGetConstant(inc);
+    if(a0 < 0.0)
+        daceMultiplyDouble(inc, -1.0, inc);
+}
+
 /*! Truncate the constant part of a DA object to an integer.
    \param[in] ina Pointer to the DA object to operate on
    \param[out] inc Pointer to the DA object to store the result in
@@ -684,7 +700,7 @@ void daceRound(const DACEDA *ina, DACEDA *inc)
 void daceModulo(const DACEDA *ina, const double p, DACEDA *inc)
 {
     daceCopy(ina, inc);
-    daceSetCoefficient0(inc, 0, fmod(daceGetConstant(inc),p));
+    daceSetCoefficient0(inc, 0, fmod(daceGetConstant(inc), p));
 }
 
 /*! Raise a DA object to the p-th power.

--- a/core/dacenorm.c
+++ b/core/dacenorm.c
@@ -42,15 +42,6 @@
  *     DACE norm and norm estimation routines
  *********************************************************************************/
 
-/*! Compute the absolute value (maximum coefficient norm) of a DA object.
-   \param[in] ina Pointer to the DA object to take absolute value of
-   \return The absolute value of ina
-*/
-double daceAbsoluteValue(const DACEDA *ina)
-{
-    return daceNorm(ina, 0);
-}
-
 /*! Compute a norm of a DA object.
    \param[in] ina Pointer to the DA object to take norm of
    \param[in] ityp Type of norm to compute.

--- a/core/include/dace/dacebase.h
+++ b/core/include/dace/dacebase.h
@@ -214,7 +214,6 @@ DACE_API void dacePsiFunction(const DACEDA REF(ina), const unsigned int n, DACED
 /********************************************************************************
 *     DACE norm and norm estimation routines
 *********************************************************************************/
-DACE_API double daceAbsoluteValue(const DACEDA REF(ina));
 DACE_API double daceNorm(const DACEDA REF(ina), const unsigned int ityp);
 DACE_API void daceOrderedNorm(const DACEDA REF(ina), const unsigned int ivar, const unsigned int ityp, double onorm[]);
 DACE_API void daceEstimate(const DACEDA REF(ina), const unsigned int ivar, const unsigned int ityp, double c[], double err[], const unsigned int nc);

--- a/core/include/dace/dacebase.h
+++ b/core/include/dace/dacebase.h
@@ -170,6 +170,7 @@ DACE_API void daceIntegrate(const unsigned int iint, const DACEDA REF(ina), DACE
 /********************************************************************************
 *     DACE intrinsic function routines
 *********************************************************************************/
+DACE_API void daceAbsolute(const DACEDA REF(ina), DACEDA REF(inc));
 DACE_API void daceTruncate(const DACEDA REF(ina), DACEDA REF(inc));
 DACE_API void daceRound(const DACEDA REF(ina), DACEDA REF(inc));
 DACE_API void daceModulo(const DACEDA REF(ina), const double p, DACEDA REF(inc));

--- a/interfaces/cxx/AlgebraicVector.cpp
+++ b/interfaces/cxx/AlgebraicVector.cpp
@@ -37,7 +37,7 @@
 #include "dace/AlgebraicVector.h"
 #include "dace/AlgebraicVector_t.h"
 
-namespace DACE{
+namespace DACE {
 
 /***********************************************************************************
 *     Coefficient access routines

--- a/interfaces/cxx/AlgebraicVector.cpp
+++ b/interfaces/cxx/AlgebraicVector.cpp
@@ -43,7 +43,7 @@ namespace DACE {
 *     Coefficient access routines
 ************************************************************************************/
 #ifdef WITH_ALGEBRAICMATRIX
-template<> AlgebraicMatrix<double> AlgebraicVector<DA>::linear() const{
+template<> AlgebraicMatrix<double> AlgebraicVector<DA>::linear() const {
 /*! Return the linear part of a AlgebraicVector<T>. NOT DEFINED FOR TYPES OTHER THAN DA.
    \return A AlgebraicMatrix<double> of dimension size by nvar, where size is the
     size of the AlgebraicVector<T> considered and nvar is the number of variables defined
@@ -57,13 +57,13 @@ template<> AlgebraicMatrix<double> AlgebraicVector<DA>::linear() const{
     const int nvar = DA::getMaxVariables();
 
     AlgebraicMatrix<double> out(size, nvar);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
           out.setrow( i, (*this)[i].linear() );
     }
     return out;
 }
 #else
-template<> std::vector< std::vector<double> > AlgebraicVector<DA>::linear() const{
+template<> std::vector< std::vector<double> > AlgebraicVector<DA>::linear() const {
 /*! Return the linear part of a AlgebraicVector<T>. NOT DEFINED FOR TYPES OTHER THAN DA.
    \return A std::vector< std::vector<double> >, where each std::vector<double> contains
     the linear part of the corresponding DA included in the original AlgebraicVector<T>.
@@ -74,15 +74,14 @@ template<> std::vector< std::vector<double> > AlgebraicVector<DA>::linear() cons
     const size_t size = this->size();
 
     std::vector< std::vector<double> > out(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
           out[i] = (*this)[i].linear();
     }
     return out;
 }
 #endif /* WITH_ALGEBRAICMATRIX */
 
-template<> AlgebraicVector<DA> AlgebraicVector<DA>::trim(const unsigned int min, const unsigned int max) const
-{
+template<> AlgebraicVector<DA> AlgebraicVector<DA>::trim(const unsigned int min, const unsigned int max) const {
 /*! Returns an AlgebraicVector<DA> with all monomials of order less than min and greater than max removed (trimmed). The result is copied in a new AlgebraicVector<DA>.
    \param[in] min minimum order to be preserved.
    \param[in] max maximum order to be preserved.
@@ -102,7 +101,7 @@ template<> AlgebraicVector<DA> AlgebraicVector<DA>::trim(const unsigned int min,
 /***********************************************************************************
 *     Math routines
 ************************************************************************************/
-template<> AlgebraicVector<DA> AlgebraicVector<DA>::deriv(const unsigned int p) const{
+template<> AlgebraicVector<DA> AlgebraicVector<DA>::deriv(const unsigned int p) const {
 /*! Compute the derivative of a AlgebraicVector<T> with respect to variable p.
     The result is copied in a new AlgebraicVector<T>. NOT DEFINED FOR TYPES OTHER THAN DA.
    \param[in] p variable with respect to which the derivative is calculated.
@@ -113,13 +112,13 @@ template<> AlgebraicVector<DA> AlgebraicVector<DA>::deriv(const unsigned int p) 
  */
     const size_t size = this->size();
     AlgebraicVector<DA> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = (*this)[i].deriv(p);}
 
     return temp;
 }
 
-template<> AlgebraicVector<DA> AlgebraicVector<DA>::integ(const unsigned int p) const{
+template<> AlgebraicVector<DA> AlgebraicVector<DA>::integ(const unsigned int p) const {
 /*! Compute the integral of a AlgebraicVector<T> with respect to variable p.
     The result is copied in a new AlgebraicVector<T>. NOT DEFINED FOR TYPES OTHER THAN DA.
    \param[in] p variable with respect to which the integral is calculated.
@@ -130,7 +129,7 @@ template<> AlgebraicVector<DA> AlgebraicVector<DA>::integ(const unsigned int p) 
  */
     const size_t size = this->size();
     AlgebraicVector<DA> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = (*this)[i].integ(p);}
 
     return temp;
@@ -139,7 +138,7 @@ template<> AlgebraicVector<DA> AlgebraicVector<DA>::integ(const unsigned int p) 
 /***********************************************************************************
 *     Polynomial evaluation routines
 ************************************************************************************/
-template<> compiledDA AlgebraicVector<DA>::compile() const{
+template<> compiledDA AlgebraicVector<DA>::compile() const {
 /*! Compile vector of polynomials and create a compiledDA object.
    \return The compiled DA object.
    \note This DA specific function is only available in AlgebraicVector<DA>.
@@ -149,7 +148,7 @@ template<> compiledDA AlgebraicVector<DA>::compile() const{
     return compiledDA(*this);
 }
 
-template<> AlgebraicVector<DA> AlgebraicVector<DA>::plug(const unsigned int var, const double val) const{
+template<> AlgebraicVector<DA> AlgebraicVector<DA>::plug(const unsigned int var, const double val) const {
 /*! Partial evaluation of vector of polynomials. In each element of the vector,
     variable var is replaced by the value val. The resulting vector of DAs
     is returned.
@@ -162,7 +161,7 @@ template<> AlgebraicVector<DA> AlgebraicVector<DA>::plug(const unsigned int var,
  */
     const size_t size = this->size();
     AlgebraicVector<DA> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = (*this)[i].plug(var,val);}
 
     return temp;
@@ -177,20 +176,20 @@ template<> AlgebraicVector<DA> AlgebraicVector<DA>::plug(const unsigned int var,
    This is NOT intended for public use. Limited error checking is performed
    in accordance with the exclusive use of this routine in map inversion.
  */
-template<> void AlgebraicVector<DA>::matrix_inverse(std::vector< std::vector<double> > &A){
+template<> void AlgebraicVector<DA>::matrix_inverse(std::vector< std::vector<double> > &A) {
     using std::abs;
 
     const size_t n = A.size();
     std::vector<size_t> indexc(n), indexr(n), ipiv(n, 0);
 
-    for (size_t i=0; i<n; i++){
+    for (size_t i=0; i<n; i++) {
         size_t icol = 0, irow = 0;
         double big = 0.0;
         for (size_t j=0; j<n; j++)
             if (ipiv[j] == 0)
                 for (size_t k=0; k<n; k++)
                     if (ipiv[k] == 0)
-                        if (abs(A[j][k]) >= big){
+                        if (abs(A[j][k]) >= big) {
                             big = abs(A[j][k]);
                             irow = j;
                             icol = k;}
@@ -204,7 +203,7 @@ template<> void AlgebraicVector<DA>::matrix_inverse(std::vector< std::vector<dou
         A[icol][icol] = 1.0;
         for (size_t l=0; l<n; l++) A[icol][l] *= pivinv;
         for (size_t ll=0; ll<n; ll++)
-            if (ll != icol){
+            if (ll != icol) {
                 const double temp = A[ll][icol];
                 A[ll][icol] = 0.0;
                 for (size_t l=0; l<n; l++) A[ll][l] -= A[icol][l]*temp;}
@@ -218,7 +217,7 @@ template<> void AlgebraicVector<DA>::matrix_inverse(std::vector< std::vector<dou
 /*! \endcond */
 #endif /* WITH_ALGEBRAICMATRIX */
 
-template<> AlgebraicVector<DA> AlgebraicVector<DA>::invert() const{
+template<> AlgebraicVector<DA> AlgebraicVector<DA>::invert() const {
 /*! Invert the polynomials map given by the AlgebraicVector<DA>.
    \return the inverted polynomials
    \throw std::runtime_error
@@ -258,13 +257,13 @@ template<> AlgebraicVector<DA> AlgebraicVector<DA>::invert() const{
     // Compute DA representation of the inverse of the linear part of the map and its composition with non-linear part AN
     AlgebraicVector<DA> Linv(nvar);
     // Linv = AI*AN
-    for(size_t i=0; i<nvar; i++){
+    for(size_t i=0; i<nvar; i++) {
         Linv[i] = 0.0;
         for(size_t j=0; j<nvar; j++)
             Linv[i] += AI[i][j]*AN[j];}
     compiledDA AIoAN(Linv);
     // Linv = AI*DDA
-    for(size_t i=0; i<nvar; i++){
+    for(size_t i=0; i<nvar; i++) {
         Linv[i] = 0.0;
         for(size_t j=0; j<nvar; j++)
             Linv[i] += AI[i][j]*DDA[j];}
@@ -272,7 +271,7 @@ template<> AlgebraicVector<DA> AlgebraicVector<DA>::invert() const{
 
     // Iterate to obtain the inverse map
     AlgebraicVector<DA> MI = Linv;
-    for(unsigned int i=1; i<ord; i++){
+    for(unsigned int i=1; i<ord; i++) {
         DA::setTO(i+1);
         MI = Linv - AIoAN.eval(MI);}
 
@@ -282,7 +281,7 @@ template<> AlgebraicVector<DA> AlgebraicVector<DA>::invert() const{
 /********************************************************************************
 *     Static factory routines
 *********************************************************************************/
-template<> AlgebraicVector<DA> AlgebraicVector<DA>::identity(const size_t n){
+template<> AlgebraicVector<DA> AlgebraicVector<DA>::identity(const size_t n) {
 /*! Return the DA identity of dimension n.
    \param[in] n The dimendion of the identity.
    \return AlgebraicVector<DA> containing the DA identity in n dimensions
@@ -291,7 +290,7 @@ template<> AlgebraicVector<DA> AlgebraicVector<DA>::identity(const size_t n){
     error will be the result.
  */
     AlgebraicVector<DA> temp(n);
-    for(size_t i=0; i < n; i++){
+    for(size_t i=0; i < n; i++) {
         temp[i] = DA((int)(i+1));}
 
     return temp;
@@ -301,7 +300,7 @@ template<> AlgebraicVector<DA> AlgebraicVector<DA>::identity(const size_t n){
 *     Non-member functions
 ************************************************************************************/
 #ifdef WITH_ALGEBRAICMATRIX
-template<> AlgebraicMatrix<double> linear(const AlgebraicVector<DA> &obj){
+template<> AlgebraicMatrix<double> linear(const AlgebraicVector<DA> &obj) {
 /*! Return the linear part of a AlgebraicVector<T>.
    \param[in] obj AlgebraicVector<T> to extract linear part from
    \return An AlgebraicMatrix<double> of dimensions size by nvar, where
@@ -313,7 +312,7 @@ template<> AlgebraicMatrix<double> linear(const AlgebraicVector<DA> &obj){
    \sa AlgebraicVector<T>::linear
  */
 #else
-template<> std::vector< std::vector<double> > linear(const AlgebraicVector<DA> &obj){
+template<> std::vector< std::vector<double> > linear(const AlgebraicVector<DA> &obj) {
 /*! Return the linear part of a AlgebraicVector<T>. Only defined for AlgebraicVector<DA>.
    \param[in] obj AlgebraicVector<T> to extract linear part from
    \return A std::vector< std::vector<double> > containing the linear parts of
@@ -327,7 +326,7 @@ template<> std::vector< std::vector<double> > linear(const AlgebraicVector<DA> &
     return obj.linear();
 }
 
-template<> AlgebraicVector<DA> trim(const AlgebraicVector<DA> &obj, unsigned int min, unsigned int max){
+template<> AlgebraicVector<DA> trim(const AlgebraicVector<DA> &obj, unsigned int min, unsigned int max) {
 /*! Returns an AlgebraicVector<DA> with all monomials of order less than min and greater than max removed (trimmed). The result is copied in a new AlgebraicVector<DA>.
    \param[in] obj the AlgebraicVector<DA> to be trimmed.
    \param[in] min minimum order to be preserved.
@@ -341,7 +340,7 @@ template<> AlgebraicVector<DA> trim(const AlgebraicVector<DA> &obj, unsigned int
     return obj.trim(min, max);
 }
 
-template<> AlgebraicVector<DA> deriv(const AlgebraicVector<DA> &obj, const unsigned int p){
+template<> AlgebraicVector<DA> deriv(const AlgebraicVector<DA> &obj, const unsigned int p) {
 /*! Compute the derivative of a AlgebraicVector<T> with respect to variable p.
     The result is copied in a new AlgebraicVector<T>.
    \param[in] obj AlgebraicVector<T>.
@@ -355,7 +354,7 @@ template<> AlgebraicVector<DA> deriv(const AlgebraicVector<DA> &obj, const unsig
     return obj.deriv(p);
 }
 
-template<> AlgebraicVector<DA> integ(const AlgebraicVector<DA> &obj, const unsigned int p){
+template<> AlgebraicVector<DA> integ(const AlgebraicVector<DA> &obj, const unsigned int p) {
 /*! Compute the integral of a AlgebraicVector<T> with respect to variable p.
     The result is copied in a new AlgebraicVector<T>.
    \param[in] obj AlgebraicVector<T>.
@@ -369,7 +368,7 @@ template<> AlgebraicVector<DA> integ(const AlgebraicVector<DA> &obj, const unsig
     return obj.integ(p);
 }
 
-template<> compiledDA compile(const AlgebraicVector<DA> &obj){
+template<> compiledDA compile(const AlgebraicVector<DA> &obj) {
 /*! Compile vector of polynomials and create a compiledDA object.
    \param[in] obj The AlgebraicVector to compile.
    \return The compiled DA object.
@@ -380,7 +379,7 @@ template<> compiledDA compile(const AlgebraicVector<DA> &obj){
     return obj.compile();
 }
 
-template<> AlgebraicVector<DA> plug(const AlgebraicVector<DA> &obj, const unsigned int var, const double val){
+template<> AlgebraicVector<DA> plug(const AlgebraicVector<DA> &obj, const unsigned int var, const double val) {
 /*! Partial evaluation of vector of polynomials. In each element of the vector,
     variable var is replaced by the value val. The resulting vector of DAs
     is returned.

--- a/interfaces/cxx/DA.cpp
+++ b/interfaces/cxx/DA.cpp
@@ -966,6 +966,21 @@ DA DA::trim(const unsigned int min, const unsigned int max) const{
     return temp;
 }
 
+DA DA::absolute() const{
+/*! Absolute value of a DA object.
+    Returns either the DA or the negative of the DA based on the constant part.
+   \return A new DA object with the absolute value DA.
+   \throw DACE::DACEException
+   \sa DA::abs
+   \sa DA::norm
+ */
+    DA temp;
+    daceAbsolute(m_index, temp.m_index);
+    if(daceGetError()) DACEException();
+
+    return temp;
+}
+
 DA DA::trunc() const{
 /*! Truncate the constant part of a DA object to an integer.
     The result is copied in a new DA object.
@@ -2069,6 +2084,18 @@ DA trim(const DA &da, const unsigned int min, const unsigned int max){
    \sa DA::trim
  */
     return da.trim(min,max);}
+
+DA absolute(const DA &da){
+/*! Absolute value of a DA object.
+    Returns either the DA or the negative of the DA based on the constant part.
+   \param[in] da a given DA object.
+   \return A new DA object with the absolute value DA.
+   \throw DACE::DACEException
+   \sa DA::absolute
+   \sa DA::abs
+   \sa DA::norm
+ */
+    return da.absolute();}
 
 DA trunc(const DA &da){
 /*! Truncate the constant part of a DA object to an integer.

--- a/interfaces/cxx/DA.cpp
+++ b/interfaces/cxx/DA.cpp
@@ -1534,23 +1534,10 @@ unsigned int DA::size() const{
    \return The number of non-zero coefficients stored in the DA object.
    \throw DACE::DACEException
  */
-    unsigned int res;
-    res=daceGetLength(m_index);
+    const unsigned int res = daceGetLength(m_index);
     if(daceGetError()) DACEException();
 
     return res;
-}
-
-double DA::abs() const{
-/*! Compute the max norm of a DA object.
-   \return A double corresponding to the result of the operation.
-   \throw DACE::DACEException
- */
-    double c;
-    c=daceAbsoluteValue(m_index);
-    if(daceGetError()) DACEException();
-
-    return c;
 }
 
 double DA::norm(const unsigned int type) const{
@@ -1562,8 +1549,7 @@ double DA::norm(const unsigned int type) const{
    \return A double corresponding to the result of the operation.
    \throw DACE::DACEException
  */
-    double c;
-    c=daceNorm(m_index, type);
+    const double c = daceNorm(m_index, type);
     if(daceGetError()) DACEException();
 
     return c;
@@ -1582,7 +1568,7 @@ std::vector<double> DA::orderNorm(const unsigned int var, const unsigned int typ
    \throw DACE::DACEException
  */
     std::vector<double> v(daceGetMaxOrder()+1);
-    daceOrderedNorm(m_index, var, type, v.data()); // Note: v.data() is C++11
+    daceOrderedNorm(m_index, var, type, v.data());
     if(daceGetError()) DACEException();
 
     return v;
@@ -1604,7 +1590,7 @@ std::vector<double> DA::estimNorm(const unsigned int var, const unsigned int typ
    \note If estimation is not possible, zero is returned for all requested orders.
  */
     std::vector<double> v(nc+1);
-    daceEstimate(m_index, var, type, v.data(), NULL ,nc); // Note: v.data() is C++11
+    daceEstimate(m_index, var, type, v.data(), NULL, nc);
     if(daceGetError()) DACEException();
 
     return v;
@@ -2582,15 +2568,6 @@ unsigned int size(const DA &da){
  */
     return da.size();}
 
-double abs(const DA &da){
-/*! Compute the max norm of a DA object.
-   \param[in] da a given DA object.
-   \return A double corresponding to the result of the operation.
-   \throw DACE::DACEException
-   \sa DA::abs
- */
-    return da.abs();}
-
 double norm(const DA &da, unsigned int type){
 /*! Compute different types of norms for a DA object.
    \param[in] da a given DA object.
@@ -2759,6 +2736,38 @@ void write(const DA &da, std::ostream &os){
  */
     return da.write(os);}
 
+namespace abs_cons {
+    double abs(const DA &da){
+/*! Absolute value of constant part.
+   \param[in] da a given DA object.
+   \throw DACE::DACEException
+   \sa DA::cons
+ */
+        return std::abs(da.cons());
+    }
+}
+
+namespace abs_max {
+    double abs(const DA &da){
+/*! Largest coefficient in absolute value.
+   \param[in] da a given DA object.
+   \throw DACE::DACEException
+   \sa DA::norm
+ */
+        return da.norm(0);
+    }
+}
+
+namespace abs_sum {
+    double abs(const DA &da){
+/*! Sum of absolute values of all coefficients.
+   \param[in] da a given DA object.
+   \throw DACE::DACEException
+   \sa DA::norm
+ */
+        return da.norm(1);
+    }
+}
 
 // static class variables
 const unsigned int storedDA::headerSize = daceBlobSize(NULL);

--- a/interfaces/cxx/MathExtension.cpp
+++ b/interfaces/cxx/MathExtension.cpp
@@ -64,6 +64,13 @@ double isrt(const double x){
     return 1.0/std::sqrt(x);
 }
 
+double icbrt(const double x){
+/*! Inverse cube root 1/cbrt(x).
+   \param[in] x Function argument.
+ */
+    return 1.0/std::cbrt(x);
+}
+
 double sqr(const double x){
 /*! Square of x.
    \param[in] x Function argument.

--- a/interfaces/cxx/MathExtension.cpp
+++ b/interfaces/cxx/MathExtension.cpp
@@ -93,4 +93,12 @@ double root(const double x, const int p){
     return std::pow(x, 1.0/p);
 }
 
+double norm(const double x, const int p){
+/*! norm of x.
+   \param[in] x Function argument.
+   \param[in] type Type of norm (ignored for double).
+ */
+    return std::abs(x);
+}
+
 }

--- a/interfaces/cxx/MathExtension.cpp
+++ b/interfaces/cxx/MathExtension.cpp
@@ -35,6 +35,13 @@
 
 namespace DACE{
 
+double absolute(const double x){
+/*! Absolute value.
+   \param[in] x Function argument.
+ */
+    return std::abs(x);
+}
+
 double cons(const double x){
 /*! Constant part. For double type this is just x.
    \param[in] x Function argument.

--- a/interfaces/cxx/include/dace/AlgebraicVector.h
+++ b/interfaces/cxx/include/dace/AlgebraicVector.h
@@ -88,11 +88,25 @@ public:
     /***********************************************************************************
     *     Math routines
     ************************************************************************************/
-    // Included also in the std library cmath
+    AlgebraicVector<T> absolute() const;                                                            //!< Element-wise absolute value function.
+    AlgebraicVector<T> trunc() const;                                                               //!< Element-wise truncation.
+    AlgebraicVector<T> round() const;                                                               //!< Element-wise rounding.
+    AlgebraicVector<T> mod() const;                                                                 //!< Element-wise modulo.
     AlgebraicVector<T> pow(const int p) const;                                                      //!< Element-wise exponentiation to (integer) power.
+    AlgebraicVector<T> pow(const double p) const;                                                   //!< Element-wise exponentiation to (double) power.
+    AlgebraicVector<T> root(const int p = 2) const;                                                 //!< Element-wise p-th root.
+    AlgebraicVector<T> minv() const;                                                                //!< Element-wise multiplicative inverse.
+    AlgebraicVector<T> sqr() const;                                                                 //!< Element-wise square.
     AlgebraicVector<T> sqrt() const;                                                                //!< Element-wise square root.
+    AlgebraicVector<T> isrt() const;                                                                //!< Element-wise inverse square root.
+    AlgebraicVector<T> cbrt() const;                                                                //!< Element-wise cube root.
+    AlgebraicVector<T> icbrt() const;                                                               //!< Element-wise inverse cube root.
+    AlgebraicVector<T> hypot(const AlgebraicVector<T> &obj) const;                                  //!< Element-wise hypotenuse.
     AlgebraicVector<T> exp() const;                                                                 //!< Element-wise exponential.
     AlgebraicVector<T> log() const;                                                                 //!< Element-wise natural logarithm.
+    AlgebraicVector<T> logb(const double b = 10.0) const;                                           //!< Element-wise logarithm wrt a given base.
+    AlgebraicVector<T> log10() const;                                                               //!< Element-wise logarithm to base 10.
+    AlgebraicVector<T> log2() const;                                                                //!< Element-wise logarithm to base 2.
     AlgebraicVector<T> sin() const;                                                                 //!< Element-wise sine.
     AlgebraicVector<T> cos() const;                                                                 //!< Element-wise cosine.
     AlgebraicVector<T> tan() const;                                                                 //!< Element-wise tangent.
@@ -103,18 +117,9 @@ public:
     AlgebraicVector<T> sinh() const;                                                                //!< Element-wise hyperbolic sine.
     AlgebraicVector<T> cosh() const;                                                                //!< Element-wise hyperbolic cosine.
     AlgebraicVector<T> tanh() const;                                                                //!< Element-wise hyperbolic tangent.
-
-    // Available in cmath for double only with C++11
     AlgebraicVector<T> asinh() const;                                                               //!< Element-wise hyperbolic arcsine.
     AlgebraicVector<T> acosh() const;                                                               //!< Element-wise hyperbolic arccosine.
     AlgebraicVector<T> atanh() const;                                                               //!< Element-wise hyperbolic arctangent.
-
-    // Our own math extension routines not included in cmath
-    AlgebraicVector<T> logb(const double b = 10.0) const;                                           //!< Element-wise logarithm wrt a given base.
-    AlgebraicVector<T> isrt() const;                                                                //!< Element-wise inverse square root.
-    AlgebraicVector<T> sqr() const;                                                                 //!< Element-wise square.
-    AlgebraicVector<T> minv() const;                                                                //!< Element-wise multiplicative inverse.
-    AlgebraicVector<T> root(const int p = 2) const;                                                 //!< Element-wise p-th root.
 
     /***********************************************************************************
     *    Vector routines
@@ -123,7 +128,7 @@ public:
                                                                                                     //!< Dot product (scalar product, inner product) of two vectors.
     template<typename V> AlgebraicVector<typename PromotionTrait<T,V>::returnType> cross(const AlgebraicVector<V> &obj) const;
                                                                                                     //!< Cross product of two vectors of length 3.
-    T vnorm() const;                                                                                //!< Euclidean vector norm (length).
+    T length() const;                                                                     //!< Length of the vector in Euclidean norm.
     AlgebraicVector<T> normalize() const;                                                           //!< Normalized vector of unit length along this vector.
 
     /***********************************************************************************
@@ -139,10 +144,9 @@ public:
     AlgebraicVector<T> trim(const unsigned int min, const unsigned int max = DA::getMaxOrder()) const;
                                                                                                     //!< Trim the coefficients of each components to particular orders. DA only.
     AlgebraicVector<T> invert() const;                                                              //!< Inverse function of the AlgebraicVector<DA>. DA only.
-    // XXX: define and add the norm estimation routines from DA including abs(), norm(p), convergence radius estimation
+    // XXX: define and add the norm estimation routines from DA including norm(p), convergence radius estimation
     // XXX: add jacobian routine (returns a DA matrix containing the jacobian)
     /*
-    double abs() const;                                                     //!< Maximum absolute value of all coefficients
     double norm(const unsigned int type = 0) const;                         //!< Different types of norms over all coefficients
     std::vector<double> orderNorm(const unsigned int var = 0, const unsigned int type = 0) const;
                                                                             //!< Different types of norms over coefficients of each order separately

--- a/interfaces/cxx/include/dace/AlgebraicVector.h
+++ b/interfaces/cxx/include/dace/AlgebraicVector.h
@@ -128,8 +128,9 @@ public:
                                                                                                     //!< Dot product (scalar product, inner product) of two vectors.
     template<typename V> AlgebraicVector<typename PromotionTrait<T,V>::returnType> cross(const AlgebraicVector<V> &obj) const;
                                                                                                     //!< Cross product of two vectors of length 3.
-    T length() const;                                                                     //!< Length of the vector in Euclidean norm.
+    T length() const;                                                                               //!< Length of the vector in Euclidean norm.
     AlgebraicVector<T> normalize() const;                                                           //!< Normalized vector of unit length along this vector.
+    // XXX: various Jacobians, gradients, curls, etc?
 
     /***********************************************************************************
     *     Special routines (DA related)
@@ -144,10 +145,12 @@ public:
     AlgebraicVector<T> trim(const unsigned int min, const unsigned int max = DA::getMaxOrder()) const;
                                                                                                     //!< Trim the coefficients of each components to particular orders. DA only.
     AlgebraicVector<T> invert() const;                                                              //!< Inverse function of the AlgebraicVector<DA>. DA only.
-    // XXX: define and add the norm estimation routines from DA including norm(p), convergence radius estimation
-    // XXX: add jacobian routine (returns a DA matrix containing the jacobian)
-    /*
-    double norm(const unsigned int type = 0) const;                         //!< Different types of norms over all coefficients
+
+    /********************************************************************************
+    *     DA norm routines
+    *********************************************************************************/
+    AlgebraicVector<double> norm(const unsigned int type = 0) const;                                //!< Element-wise DA norm
+    /* XXX: define and add the norm estimation routines from DA including convergence radius estimation
     std::vector<double> orderNorm(const unsigned int var = 0, const unsigned int type = 0) const;
                                                                             //!< Different types of norms over coefficients of each order separately
     std::vector<double> estimNorm(const unsigned int var = 0, const unsigned int type = 0, const unsigned int nc = DA::getMaxOrder()) const;
@@ -233,6 +236,7 @@ template<typename T, typename U> AlgebraicVector<U> eval(const AlgebraicVector<T
 template<typename T, typename U> AlgebraicVector<U> evalScalar(const AlgebraicVector<T> &obj, const U &arg);
 template<typename T> compiledDA compile(const AlgebraicVector<T> &obj);
 template<typename T> AlgebraicVector<T> plug(const AlgebraicVector<T> &obj, const unsigned int var, const double val = 0.0);
+template<typename T> AlgebraicVector<double> norm(const AlgebraicVector<T> &obj, const unsigned int type = 0);
 
 // specializations for various DA specific routines implemented and instantiated directly in the library instead of in a template
 #ifdef WITH_ALGEBRAICMATRIX

--- a/interfaces/cxx/include/dace/AlgebraicVector_t.h
+++ b/interfaces/cxx/include/dace/AlgebraicVector_t.h
@@ -438,41 +438,6 @@ template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >:
     return temp;
 }
 
-template<typename T> template<typename V> typename PromotionTrait<T,V>::returnType AlgebraicVector<T>::dot(const AlgebraicVector<V> &obj) const {
-/*! Compute the dot product with another AlgebraicVector.
-   \param[in] obj the other AlgebraicVector.
-   \return A scalar value,.
-   \throw std::runtime_error
- */
-    const size_t size = this->size();
-    if(size != obj.size())
-          throw std::runtime_error("DACE::AlgebraicVector<T>::dot(): Vectors must have the same length.");
-
-    typename PromotionTrait<T,V>::returnType temp = 0.0;
-    for(size_t i=0; i<size; i++) {
-        temp += (*this)[i] * obj[i];}
-
-    return temp;
-}
-
-template<typename T> template<typename V> AlgebraicVector<typename PromotionTrait<T,V>::returnType> AlgebraicVector<T>::cross(const AlgebraicVector<V> &obj) const {
-/*! Compute the cross product with another 3D AlgebraicVector.
-   \param[in] obj The other AlgebraicVector.
-   \return A new AlgebraicVector.
-   \throw std::runtime_error
- */
-    if((this->size() != 3) || (obj.size() != 3))
-        throw std::runtime_error("DACE::AlgebraicVector<T>::cross(): Inputs must be 3 element AlgebraicVectors.");
-
-    AlgebraicVector<typename PromotionTrait<T,V>::returnType> temp(3);
-
-    temp[0] = ((*this)[1] * obj[2]) - ((*this)[2] * obj[1]);
-    temp[1] = ((*this)[2] * obj[0]) - ((*this)[0] * obj[2]);
-    temp[2] = ((*this)[0] * obj[1]) - ((*this)[1] * obj[0]);
-
-    return temp;
-}
-
 /***********************************************************************************
 *     Math routines
 ************************************************************************************/
@@ -937,8 +902,43 @@ template<typename T> AlgebraicVector<T> AlgebraicVector<T>::atanh() const {
 }
 
 /***********************************************************************************
-*    Vector norm routines
+*    Vector routines
 ************************************************************************************/
+template<typename T> template<typename V> typename PromotionTrait<T,V>::returnType AlgebraicVector<T>::dot(const AlgebraicVector<V> &obj) const {
+/*! Compute the dot product with another AlgebraicVector.
+   \param[in] obj the other AlgebraicVector.
+   \return A scalar value,.
+   \throw std::runtime_error
+ */
+    const size_t size = this->size();
+    if(size != obj.size())
+          throw std::runtime_error("DACE::AlgebraicVector<T>::dot(): Vectors must have the same length.");
+
+    typename PromotionTrait<T,V>::returnType temp = 0.0;
+    for(size_t i=0; i<size; i++) {
+        temp += (*this)[i] * obj[i];}
+
+    return temp;
+}
+
+template<typename T> template<typename V> AlgebraicVector<typename PromotionTrait<T,V>::returnType> AlgebraicVector<T>::cross(const AlgebraicVector<V> &obj) const {
+/*! Compute the cross product with another 3D AlgebraicVector.
+   \param[in] obj The other AlgebraicVector.
+   \return A new AlgebraicVector.
+   \throw std::runtime_error
+ */
+    if((this->size() != 3) || (obj.size() != 3))
+        throw std::runtime_error("DACE::AlgebraicVector<T>::cross(): Inputs must be 3 element AlgebraicVectors.");
+
+    AlgebraicVector<typename PromotionTrait<T,V>::returnType> temp(3);
+
+    temp[0] = ((*this)[1] * obj[2]) - ((*this)[2] * obj[1]);
+    temp[1] = ((*this)[2] * obj[0]) - ((*this)[0] * obj[2]);
+    temp[2] = ((*this)[0] * obj[1]) - ((*this)[1] * obj[0]);
+
+    return temp;
+}
+
 template<typename T> T AlgebraicVector<T>::length() const {
 /*! Compute the length (Euclidean vector norm).
    \return Length of the vector.
@@ -1008,6 +1008,25 @@ template<> template<typename U> AlgebraicVector<U> AlgebraicVector<DA>::evalScal
    \sa AlgebraicVector::compile()
  */
     return compiledDA(*this).evalScalar(arg);
+}
+
+/***********************************************************************************
+*     DA norm routines
+************************************************************************************/
+template<typename T> AlgebraicVector<double> AlgebraicVector<T>::norm(const unsigned int type) const {
+/*! Element-wise application of the norm function.
+   \param[in] type type of norm to be computed. See DA::norm.
+   \return A new AlgebraicVector<T>.
+   \sa DA::norm()
+ */
+    using DACE::norm;
+
+    const size_t size = this->size();
+    AlgebraicVector<T> temp(size);
+    for(size_t i=0; i<size; i++) {
+        temp[i] = norm((*this)[i], type);}
+
+    return temp;
 }
 
 /***********************************************************************************
@@ -1450,6 +1469,18 @@ template<typename U> AlgebraicVector<U> evalScalar(const AlgebraicVector<DA> &ob
  */
     return obj.evalScalar(arg);
 }
+
+template<typename T> AlgebraicVector<double> norm(const AlgebraicVector<T> &obj, const unsigned int type) {
+/*! Element-wise application of the norm function.
+   \param[in] obj AlgebraicVector<T>.
+   \param[in] type type of norm to be computed. See DA::norm.
+   \return A new AlgebraicVector<T>.
+   \sa AlgebraicVector<T>::norm
+   \sa DA::norm
+ */
+    return obj.norm(type);
+}
+
 
 }
 #endif /* DINAMICA_ALGEBRAICVECTOR_T_H_ */

--- a/interfaces/cxx/include/dace/AlgebraicVector_t.h
+++ b/interfaces/cxx/include/dace/AlgebraicVector_t.h
@@ -45,42 +45,42 @@
 #include "dace/AlgebraicMatrix_t.h"
 #endif /* WITH_ALGEBRAICMATRIX */
 
-namespace DACE{
+namespace DACE {
 
 /***********************************************************************************
 *     Constructors
 ************************************************************************************/
-template<typename T> AlgebraicVector<T>::AlgebraicVector() : std::vector<T>(){
+template<typename T> AlgebraicVector<T>::AlgebraicVector() : std::vector<T>() {
 /*! Default Constructor to create empty AlgebraicVector
  */
 }
 
-template<typename T> AlgebraicVector<T>::AlgebraicVector(size_t size) : std::vector<T>(size){
+template<typename T> AlgebraicVector<T>::AlgebraicVector(size_t size) : std::vector<T>(size) {
 /*! Constructor with size to allocate a vector of the given size with elements initialized using their default constructor.
    \param[in] size length of AlgebraicVector.
  */
 }
 
-template<typename T> AlgebraicVector<T>::AlgebraicVector(size_t size, const T &d) : std::vector<T>(size, d){
+template<typename T> AlgebraicVector<T>::AlgebraicVector(size_t size, const T &d) : std::vector<T>(size, d) {
 /*! Constructor with size and elements value to allocate a vector of the given size with elements initialized as copies of d.
    \param[in] size length of AlgebraicVector
    \param[in] d    initial value for the elements
  */
 }
 
-template<typename T> AlgebraicVector<T>::AlgebraicVector(const std::vector<T> &v) : std::vector<T>(v){
+template<typename T> AlgebraicVector<T>::AlgebraicVector(const std::vector<T> &v) : std::vector<T>(v) {
 /*! Copy constructor to create a copy of any existing vector.
    \param[in] v vector to be copied into AlgebraicVector
  */
 }
 
-template<typename T> AlgebraicVector<T>::AlgebraicVector(std::initializer_list<T> l) : std::vector<T>(l){
+template<typename T> AlgebraicVector<T>::AlgebraicVector(std::initializer_list<T> l) : std::vector<T>(l) {
 /*! Constructor to create a vector from an initializer list.
    \param[in] l braced initializer list to be copied into the AlgebraicVector
  */
 }
 
-template<typename T> AlgebraicVector<T>::AlgebraicVector(const std::vector<T> &v, size_t first, size_t last) : std::vector<T>(v.begin()+first, v.begin()+last+1){
+template<typename T> AlgebraicVector<T>::AlgebraicVector(const std::vector<T> &v, size_t first, size_t last) : std::vector<T>(v.begin()+first, v.begin()+last+1) {
 /*! Extraction constructor to copy only a given range of elements from vector v.
    \param[in] v vector to be copied into AlgebraicVector
    \param[in] first index of the first element to be copied
@@ -96,24 +96,21 @@ template<typename T> AlgebraicVector<T>::AlgebraicVector(const std::vector<T> &v
 /***********************************************************************************
 *     Coefficient access routines
 ************************************************************************************/
-template<typename T> AlgebraicVector<double> AlgebraicVector<T>::cons() const{
-/*! Return the constant part of a AlgebraicVector<T>.
-   \return A AlgebraicVector<double> of dimension 1 by size, where size is the
-    size of the AlgebraicVector<T>. Each element contains the constant part of
-    the corresponding value included in the original AlgebraicVector<T>.
+template<typename T> AlgebraicVector<double> AlgebraicVector<T>::cons() const {
+/*! Return the constant parts of each element.
+   \return A AlgebraicVector<double> containing the constant part of each element.
  */
     using DACE::cons;
 
     const size_t size = this->size();
     AlgebraicVector<double> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = cons((*this)[i]);}
 
     return temp;
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::extract(const size_t first, const size_t last) const
-{
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::extract(const size_t first, const size_t last) const {
 /*! Extracts elements from AlgebraicVector.
    \param[in] first index of first element to be extracted
    \param[in] last  index of last element to be extracted
@@ -127,7 +124,7 @@ template<typename T> AlgebraicVector<T> AlgebraicVector<T>::extract(const size_t
     return AlgebraicVector<T>(*this, first, last);
 }
 
-template<typename T> template<typename V> AlgebraicVector<typename PromotionTrait< T, V >::returnType> AlgebraicVector<T>::concat(const std::vector<V> &obj) const{
+template<typename T> template<typename V> AlgebraicVector<typename PromotionTrait< T, V >::returnType> AlgebraicVector<T>::concat(const std::vector<V> &obj) const {
 /*! Append an AlgebraicVector to the end of the current one and return the new vector.
    \param[in] obj The AlgebraicVector to be appended.
    \return A new AlgebraicVector containing the elements of both vectors,
@@ -148,14 +145,14 @@ template<typename T> template<typename V> AlgebraicVector<typename PromotionTrai
 /***********************************************************************************
 *     Algebraic operations
 ************************************************************************************/
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::operator-() const{
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::operator-() const {
 /*! Returns the additive inverse of the vector.
    \return A new AlgebraicVector, with the opposite sign.
  */
     return -1.0*(*this);
 }
 
-template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator+=(const AlgebraicVector<U> &obj){
+template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator+=(const AlgebraicVector<U> &obj) {
 /*! Add the given AlgebraicVector to ourselves.
    \param[in] obj An AlgebraicVector.
    \return A reference to ourselves.
@@ -165,23 +162,23 @@ template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>
     if(size != obj.size())
         throw std::runtime_error("DACE::AlgebraicVector<T>::operator+=: Vectors must have the same length.");
 
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         (*this)[i] += obj[i];}
     return *this;
 }
 
-template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator+=(const U &obj){
+template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator+=(const U &obj) {
 /*! Add the given scalar to ourselves componentwise.
    \param[in] obj A scalar value.
    \return A reference to ourselves.
  */
     const size_t size = this->size();
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         (*this)[i] += obj;}
     return *this;
 }
 
-template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator-=(const AlgebraicVector<U> &obj){
+template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator-=(const AlgebraicVector<U> &obj) {
 /*! Subtract the given AlgebraicVector from ourselves.
    \param[in] obj An AlgebraicVector.
    \return A reference to ourselves.
@@ -191,23 +188,23 @@ template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>
     if(size != obj.size())
         throw std::runtime_error("DACE::AlgebraicVector<T>::operator-=: Vectors must have the same length.");
 
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         (*this)[i] -= obj[i];}
     return *this;
 }
 
-template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator-=(const U &obj){
+template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator-=(const U &obj) {
 /*! Subtract the given scalar from ourselves componentwise.
    \param[in] obj A scalar value.
    \return A reference to ourselves.
  */
     const size_t size = this->size();
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         (*this)[i] -= obj;}
     return *this;
 }
 
-template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator*=(const AlgebraicVector<U> &obj){
+template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator*=(const AlgebraicVector<U> &obj) {
 /*! Multiply the given AlgebraicVector with ourselves componentwise.
    \param[in] obj An AlgebraicVector.
    \return A reference to ourselves.
@@ -216,23 +213,23 @@ template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>
     if(size != obj.size())
         throw std::runtime_error("DACE::AlgebraicVector<T>::operator*=: Vectors must have the same length.");
 
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         (*this)[i] *= obj[i];}
     return *this;
 }
 
-template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator*=(const U &obj){
+template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator*=(const U &obj) {
 /*! Multiply the given scalar with ourselves.
    \param[in] obj A scalar value.
    \return A reference to ourselves.
  */
     const size_t size = this->size();
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         (*this)[i] *= obj;}
     return *this;
 }
 
-template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator/=(const AlgebraicVector<U> &obj){
+template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator/=(const AlgebraicVector<U> &obj) {
 /*! Divide ourselves by the given AlgebraicVector componentwise.
    \param[in] obj An AlgebraicVector.
    \return A reference to ourselves.
@@ -242,38 +239,38 @@ template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>
     if(size != obj.size())
         throw std::runtime_error("DACE::AlgebraicVector<T>::operator/=: Vectors must have the same length.");
 
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         (*this)[i] /= obj[i];}
     return *this;
 }
 
-template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator/=(const U &obj){
+template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator/=(const U &obj) {
 /*! Divide ourselves by the given scalar.
    \param[in] obj A scalar value.
    \return A reference to ourselves.
  */
     const size_t size = this->size();
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         (*this)[i] /= obj;}
     return *this;
 }
 
-template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator<<(const std::vector<U> &obj){
+template<typename T> template<typename U> AlgebraicVector<T>& AlgebraicVector<T>::operator<<(const std::vector<U> &obj) {
 /*! Append elements of vector obj to the end of ourself, converting the type to match ours if necessary.
    \param[in] obj Vector of elements to append.
    \return A reference to ourselves.
  */
     const size_t size = obj.size();
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         (*this).push_back((T)obj[i]);}
     return *this;
 }
 
-template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator+(const AlgebraicVector<U> &obj1, const AlgebraicVector<V> &obj2){
+template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator+(const AlgebraicVector<U> &obj1, const AlgebraicVector<V> &obj2) {
 /*! Compute the addition between two AlgebraicVectors.
    \param[in] obj1 first AlgebraicVector.
    \param[in] obj2 second AlgebraicVector.
-   \return A new AlgebraicVector, containing the result of the operation (obj1+obj2).
+   \return A new AlgebraicVector, (obj1+obj2).
    \throw std::runtime_error
  */
     if(obj1.size() != obj2.size())
@@ -281,42 +278,42 @@ template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >:
 
     const size_t size = obj1.size();
     AlgebraicVector<typename PromotionTrait< U, V >::returnType> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = obj1[i] + obj2[i];}
     return temp;
 }
 
-template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator+(const AlgebraicVector<U> &obj1, const V &obj2){
+template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator+(const AlgebraicVector<U> &obj1, const V &obj2) {
 /*! Compute the addition between a AlgebraicVector and a scalar value.
    \param[in] obj1 a AlgebraicVector.
    \param[in] obj2 a scalar value.
-   \return A new AlgebraicVector, containing the result of the operation (obj1+obj2).
+   \return A new AlgebraicVector, (obj1+obj2).
  */
     const size_t size = obj1.size();
     AlgebraicVector<typename PromotionTrait< U, V >::returnType> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = obj1[i] + obj2;}
     return temp;
 }
 
-template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator+(const U &obj1, const AlgebraicVector<V> &obj2){
+template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator+(const U &obj1, const AlgebraicVector<V> &obj2) {
 /*! Compute the addition between a scalar value and a AlgebraicVector.
    \param[in] obj1 a scalar value.
    \param[in] obj2 a AlgebraicVector.
-   \return A new AlgebraicVector, containing the result of the operation (obj1+obj2).
+   \return A new AlgebraicVector, (obj1+obj2).
  */
     const size_t size = obj2.size();
     AlgebraicVector<typename PromotionTrait< U, V >::returnType> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = obj1 + obj2[i];}
     return temp;
 }
 
-template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator-(const AlgebraicVector<U> &obj1, const AlgebraicVector<V> &obj2){
+template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator-(const AlgebraicVector<U> &obj1, const AlgebraicVector<V> &obj2) {
 /*! Compute the subtraction between two AlgebraicVectors.
    \param[in] obj1 first AlgebraicVector.
    \param[in] obj2 second AlgebraicVector.
-   \return A new AlgebraicVector, containing the result of the operation (obj1-obj2).
+   \return A new AlgebraicVector, (obj1-obj2).
    \throw std::runtime_error
  */
     if(obj1.size() != obj2.size())
@@ -324,42 +321,42 @@ template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >:
 
     const size_t size = obj1.size();
     AlgebraicVector<typename PromotionTrait< U, V >::returnType> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = obj1[i] - obj2[i];}
     return temp;
 }
 
-template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator-(const AlgebraicVector<U> &obj1, const V &obj2){
+template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator-(const AlgebraicVector<U> &obj1, const V &obj2) {
 /*! Compute the subtraction between a AlgebraicVector and a scalar value.
    \param[in] obj1 a AlgebraicVector.
    \param[in] obj2 a scalar value.
-   \return A new AlgebraicVector, containing the result of the operation (obj1-obj2).
+   \return A new AlgebraicVector, (obj1-obj2).
  */
     const size_t size = obj1.size();
     AlgebraicVector<typename PromotionTrait< U, V >::returnType> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = obj1[i] - obj2;}
     return temp;
 }
 
-template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator-(const U &obj1, const AlgebraicVector<V> &obj2){
+template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator-(const U &obj1, const AlgebraicVector<V> &obj2) {
 /*! Compute the subtraction between a scalar value and a AlgebraicVector.
    \param[in] obj1 a scalar value.
    \param[in] obj2 a AlgebraicVector.
-   \return A new AlgebraicVector, containing the result of the operation (obj1-obj2).
+   \return A new AlgebraicVector, (obj1-obj2).
  */
     const size_t size = obj2.size();
     AlgebraicVector<typename PromotionTrait< U, V >::returnType> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = obj1 - obj2[i];}
     return temp;
 }
 
-template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator*(const AlgebraicVector<U> &obj1, const AlgebraicVector<V> &obj2){
+template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator*(const AlgebraicVector<U> &obj1, const AlgebraicVector<V> &obj2) {
 /*! Compute the element-wise multiplication between two AlgebraicVectors.
    \param[in] obj1 first AlgebraicVector.
    \param[in] obj2 second AlgebraicVector.
-   \return A new AlgebraicVector, containing the result of the operation (obj1*obj2).
+   \return A new AlgebraicVector, (obj1*obj2).
    \throw std::runtime_error
  */
     if(obj1.size() != obj2.size())
@@ -367,42 +364,42 @@ template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >:
 
     const size_t size = obj1.size();
     AlgebraicVector<typename PromotionTrait< U, V >::returnType> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = obj1[i] * obj2[i];}
     return temp;
 }
 
-template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator*(const AlgebraicVector<U> &obj1, const V &obj2){
+template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator*(const AlgebraicVector<U> &obj1, const V &obj2) {
 /*! Compute the multiplication between a AlgebraicVector and a scalar value.
    \param[in] obj1 a AlgebraicVector.
    \param[in] obj2 a scalar value.
-   \return A new AlgebraicVector, containing the result of the operation (obj1*obj2).
+   \return A new AlgebraicVector, (obj1*obj2).
  */
     const size_t size = obj1.size();
     AlgebraicVector<typename PromotionTrait< U, V >::returnType> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = obj1[i] * obj2;}
     return temp;
 }
 
-template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator*(const U &obj1, const AlgebraicVector<V> &obj2){
+template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator*(const U &obj1, const AlgebraicVector<V> &obj2) {
 /*! Compute the multiplication between a scalar value and a AlgebraicVector.
    \param[in] obj1 a scalar value.
    \param[in] obj2 a AlgebraicVector.
-   \return A new AlgebraicVector, containing the result of the operation (obj1*obj2).
+   \return A new AlgebraicVector, (obj1*obj2).
  */
     const size_t size = obj2.size();
     AlgebraicVector<typename PromotionTrait< U, V >::returnType> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = obj1 * obj2[i];}
     return temp;
 }
 
-template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator/(const AlgebraicVector<U> &obj1, const AlgebraicVector<V> &obj2){
+template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator/(const AlgebraicVector<U> &obj1, const AlgebraicVector<V> &obj2) {
 /*! Compute the element-wise division between two AlgebraicVectors.
    \param[in] obj1 first AlgebraicVector.
    \param[in] obj2 second AlgebraicVector.
-   \return A new AlgebraicVector, containing the result of the operation (obj1/obj2).
+   \return A new AlgebraicVector, (obj1/obj2).
    \throw std::runtime_error
  */
     if(obj1.size() != obj2.size())
@@ -410,58 +407,58 @@ template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >:
 
     const size_t size = obj1.size();
     AlgebraicVector<typename PromotionTrait< U, V >::returnType> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = obj1[i] / obj2[i];}
     return temp;
 }
 
-template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator/(const AlgebraicVector<U> &obj1, const V &obj2){
+template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator/(const AlgebraicVector<U> &obj1, const V &obj2) {
 /*! Compute the division between a AlgebraicVector and a scalar value.
    \param[in] obj1 a AlgebraicVector.
    \param[in] obj2 a scalar value.
-   \return A new AlgebraicVector, containing the result of the operation (obj1/obj2).
+   \return A new AlgebraicVector, (obj1/obj2).
  */
     const size_t size = obj1.size();
     AlgebraicVector<typename PromotionTrait< U, V >::returnType> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = obj1[i] / obj2;}
     return temp;
 }
 
-template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator/(const U &obj1, const AlgebraicVector<V> &obj2){
+template<typename U,typename V> AlgebraicVector<typename PromotionTrait< U, V >::returnType> operator/(const U &obj1, const AlgebraicVector<V> &obj2) {
 /*! Compute the division between a scalar value and a AlgebraicVector.
    \param[in] obj1 a scalar value.
    \param[in] obj2 a AlgebraicVector.
-   \return A new AlgebraicVector, containing the result of the operation (obj1/obj2).
+   \return A new AlgebraicVector, (obj1/obj2).
  */
     const size_t size = obj2.size();
     AlgebraicVector<typename PromotionTrait< U, V >::returnType> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = obj1 / obj2[i];}
     return temp;
 }
 
-template<typename T> template<typename V> typename PromotionTrait<T,V>::returnType AlgebraicVector<T>::dot(const AlgebraicVector<V> &obj) const{
+template<typename T> template<typename V> typename PromotionTrait<T,V>::returnType AlgebraicVector<T>::dot(const AlgebraicVector<V> &obj) const {
 /*! Compute the dot product with another AlgebraicVector.
    \param[in] obj the other AlgebraicVector.
-   \return A scalar value, containing the result of the operation.
+   \return A scalar value,.
    \throw std::runtime_error
  */
     const size_t size = this->size();
     if(size != obj.size())
           throw std::runtime_error("DACE::AlgebraicVector<T>::dot(): Vectors must have the same length.");
 
-    typename PromotionTrait<T,V>::returnType temp = 0;
-    for(size_t i=0; i<size; i++){
+    typename PromotionTrait<T,V>::returnType temp = 0.0;
+    for(size_t i=0; i<size; i++) {
         temp += (*this)[i] * obj[i];}
 
     return temp;
 }
 
-template<typename T> template<typename V> AlgebraicVector<typename PromotionTrait<T,V>::returnType> AlgebraicVector<T>::cross(const AlgebraicVector<V> &obj) const{
+template<typename T> template<typename V> AlgebraicVector<typename PromotionTrait<T,V>::returnType> AlgebraicVector<T>::cross(const AlgebraicVector<V> &obj) const {
 /*! Compute the cross product with another 3D AlgebraicVector.
    \param[in] obj The other AlgebraicVector.
-   \return A new AlgebraicVector, containing the result of the operation.
+   \return A new AlgebraicVector.
    \throw std::runtime_error
  */
     if((this->size() != 3) || (obj.size() != 3))
@@ -479,163 +476,367 @@ template<typename T> template<typename V> AlgebraicVector<typename PromotionTrai
 /***********************************************************************************
 *     Math routines
 ************************************************************************************/
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::pow(const int p) const{
-/*! Elevate a AlgebraicVector<T> to a given integer power.
-   The result is copied in a new AlgebraicVector<T>.
-   \param[in] p power at which the AlgebraicVector<T> is elevated.
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::absolute() const {
+/*! Element-wise application of the absolute value function.
+   \return A new AlgebraicVector<T>.
+ */
+    const size_t size = this->size();
+    AlgebraicVector<T> temp(size);
+    for(size_t i=0; i<size; i++) {
+        temp[i] = absolute((*this)[i]);}
+
+    return temp;
+}
+
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::trunc() const {
+/*! Element-wise application of the truncation function.
+   \return A new AlgebraicVector<T>.
+ */
+    using std::trunc;
+
+    const size_t size = this->size();
+    AlgebraicVector<T> temp(size);
+    for(size_t i=0; i<size; i++) {
+        temp[i] = trunc((*this)[i]);}
+
+    return temp;
+}
+
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::round() const {
+/*! Element-wise application of the round function.
+   \return A new AlgebraicVector<T>.
+ */
+    using std::round;
+
+    const size_t size = this->size();
+    AlgebraicVector<T> temp(size);
+    for(size_t i=0; i<size; i++) {
+        temp[i] = round((*this)[i]);}
+
+    return temp;
+}
+
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::mod() const {
+/*! Element-wise application of the mod function.
+   \return A new AlgebraicVector<T>.
+ */
+    using std::trunc;
+
+    const size_t size = this->size();
+    AlgebraicVector<T> temp(size);
+    for(size_t i=0; i<size; i++) {
+        temp[i] = mod((*this)[i]);}
+
+    return temp;
+}
+
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::pow(const int p) const {
+/*! Element-wise application of the integer power function.
+   \param[in] p power to raise each element to.
    \return A new AlgebraicVector<T>.
  */
     using std::pow;
 
     const size_t size = this->size();
     AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = pow((*this)[i], p);}
 
     return temp;
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::sqrt() const{
-/*! Compute the square root of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::pow(const double p) const {
+/*! Element-wise application of the double power function.
+   \param[in] p power to raise each element to.
+   \return A new AlgebraicVector<T>.
+ */
+    using std::pow;
+
+    const size_t size = this->size();
+    AlgebraicVector<T> temp(size);
+    for(size_t i=0; i<size; i++) {
+        temp[i] = pow((*this)[i], p);}
+
+    return temp;
+}
+
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::root(const int p) const {
+/*! Element-wise application of the p-th root function.
+   \param[in] p root to be computed.
+   \return A new AlgebraicVector<T>.
+ */
+    using DACE::root;
+
+    const size_t size = this->size();
+    AlgebraicVector<T> temp(size);
+    for(size_t i=0; i<size; i++) {
+        temp[i] = root((*this)[i],p);}
+
+    return temp;
+}
+
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::minv() const {
+/*! Element-wise application of the multiplicative inverse function.
+   \return A new AlgebraicVector<T>.
+ */
+    using DACE::minv;
+
+    const size_t size = this->size();
+    AlgebraicVector<T> temp(size);
+    for(size_t i=0; i<size; i++) {
+        temp[i] = minv((*this)[i]);}
+
+    return temp;
+}
+
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::sqr() const {
+/*! Element-wise application of the square function.
+   \return A new AlgebraicVector<T>.
+ */
+    using DACE::sqr;
+
+    const size_t size = this->size();
+    AlgebraicVector<T> temp(size);
+    for(size_t i=0; i<size; i++) {
+        temp[i] = sqr((*this)[i]);}
+
+    return temp;
+}
+
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::sqrt() const {
+/*! Element-wise application of the square root function.
    \return A new AlgebraicVector<T>.
  */
     using std::sqrt;
 
     const size_t size = this->size();
     AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = sqrt((*this)[i]);}
 
     return temp;
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::exp() const{
-/*! Compute the exponent of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::isrt() const {
+/*! Element-wise application of the inverse square root function.
+   \return A new AlgebraicVector<T>.
+ */
+    using DACE::isrt;
+
+    const size_t size = this->size();
+    AlgebraicVector<T> temp(size);
+    for(size_t i=0; i<size; i++) {
+        temp[i] = isrt((*this)[i]);}
+
+    return temp;
+}
+
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::cbrt() const {
+/*! Element-wise application of the cube root function.
+   \return A new AlgebraicVector<T>.
+ */
+    using std::cbrt;
+
+    const size_t size = this->size();
+    AlgebraicVector<T> temp(size);
+    for(size_t i=0; i<size; i++) {
+        temp[i] = cbrt((*this)[i]);}
+
+    return temp;
+}
+
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::icbrt() const {
+/*! Element-wise application of the inverse cube root function.
+   \return A new AlgebraicVector<T>.
+ */
+    using DACE::icbrt;
+
+    const size_t size = this->size();
+    AlgebraicVector<T> temp(size);
+    for(size_t i=0; i<size; i++) {
+        temp[i] = sqrt((*this)[i]);}
+
+    return temp;
+}
+
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::hypot(const AlgebraicVector<T> &obj) const {
+/*! Element-wise application of the hypotenuse function hypot(x,y).
+   \param[in] obj AlgebraicVector<T> second argument.
+   \return A new AlgebraicVector<T>.
+*/
+    using std::hypot;
+
+    const size_t size = this->size();
+    if(obj.size() != size)
+        throw std::runtime_error("DACE::AlgebraicVector<T>::hypot(): Vectors must have the same length.");
+
+    AlgebraicVector<T> temp(size);
+    for(size_t i=0; i<size; i++) {
+        temp[i] = hypot((*this)[i], obj[i]);}
+
+    return temp;
+}
+
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::exp() const {
+/*! Element-wise application of the exponential function.
    \return A new AlgebraicVector<T>.
  */
     using std::exp;
 
     const size_t size = this->size();
     AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = exp((*this)[i]);}
 
     return temp;
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::log() const{
-/*! Compute the natural logarithm of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::log() const {
+/*! Element-wise application of the natural logarithm function.
    \return A new AlgebraicVector<T>.
  */
     using std::log;
 
     const size_t size = this->size();
     AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = log((*this)[i]);}
 
     return temp;
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::sin() const{
-/*! Compute the sine of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::logb(const double b) const {
+/*! Element-wise application of the logarithm function relative to given base.
+   \param[in] b base for the logarithm
+   \return A new AlgebraicVector<T>.
+ */
+    using DACE::logb;
+
+    const size_t size = this->size();
+    AlgebraicVector<T> temp(size);
+    for(size_t i=0; i<size; i++) {
+        temp[i] = logb((*this)[i], b);}
+
+    return temp;
+}
+
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::log10() const {
+/*! Element-wise application of the decadic logarithm function.
+   \return A new AlgebraicVector<T>.
+ */
+    using std::log10;
+
+    const size_t size = this->size();
+    AlgebraicVector<T> temp(size);
+    for(size_t i=0; i<size; i++) {
+        temp[i] = log10((*this)[i]);}
+
+    return temp;
+}
+
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::log2() const {
+/*! Element-wise application of the binary logarithm function.
+   \return A new AlgebraicVector<T>.
+ */
+    using std::log2;
+
+    const size_t size = this->size();
+    AlgebraicVector<T> temp(size);
+    for(size_t i=0; i<size; i++) {
+        temp[i] = log2((*this)[i]);}
+
+    return temp;
+}
+
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::sin() const {
+/*! Element-wise application of the sine function.
    \return A new AlgebraicVector<T>.
  */
     using std::sin;
 
     const size_t size = this->size();
     AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = sin((*this)[i]);}
 
     return temp;
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::cos() const{
-/*! Compute the cosine of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::cos() const {
+/*! Element-wise application of the cosine function.
    \return A new AlgebraicVector<T>.
  */
     using std::cos;
 
     const size_t size = this->size();
     AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = cos((*this)[i]);}
 
     return temp;
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::tan() const{
-/*! Compute the tangent of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::tan() const {
+/*! Element-wise application of the tangent function.
    \return A new AlgebraicVector<T>.
  */
     using std::tan;
 
     const size_t size = this->size();
     AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = tan((*this)[i]);}
 
     return temp;
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::asin() const{
-/*! Compute the arcsine of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::asin() const {
+/*! Element-wise application of the arcsine function.
    \return A new AlgebraicVector<T>.
  */
     using std::asin;
 
     const size_t size = this->size();
     AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = asin((*this)[i]);}
 
     return temp;
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::acos() const{
-/*! Compute the arccosine of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::acos() const {
+/*! Element-wise application of the arccosine function.
    \return A new AlgebraicVector<T>.
  */
     using std::acos;
 
     const size_t size = this->size();
     AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = acos((*this)[i]);}
 
     return temp;
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::atan() const{
-/*! Compute the arctangent of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::atan() const {
+/*! Element-wise application of the arctangent function.
    \return A new AlgebraicVector<T>.
  */
     using std::atan;
 
     const size_t size = this->size();
     AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = atan((*this)[i]);}
 
     return temp;
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::atan2(const AlgebraicVector<T> &obj) const{
-/*! Compute the four-quadrant arctangent of Y/X. Y is the current vector,
-    whereas X is the AlgebraicVector<T> in input.
-    The result is copied in a new AlgebraicVector<T>.
-   \param[in] obj AlgebraicVector<T>
-   \return A new AlgebraicVector<T> containing the result of the operation Y/X in [-pi, pi].
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::atan2(const AlgebraicVector<T> &obj) const {
+/*! Element-wise application of the four-quadrant arctangent of Y/X.
+    Y is the current object, whereas X is the argument.
+   \param[in] obj AlgebraicVector<T> representing X
+   \return A new AlgebraicVector<T> with elements in [-pi, pi].
    \throw std::runtime_error
 */
     using std::atan2;
@@ -645,174 +846,91 @@ template<typename T> AlgebraicVector<T> AlgebraicVector<T>::atan2(const Algebrai
         throw std::runtime_error("DACE::AlgebraicVector<T>::atan2(): Vectors must have the same length.");
 
     AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = atan2((*this)[i], obj[i]);}
 
     return temp;
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::sinh() const{
-/*! Compute the hyperbolic sine of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::sinh() const {
+/*! Element-wise application of the hyperbolic sine function.
    \return A new AlgebraicVector<T>.
  */
     using std::sinh;
 
     const size_t size = this->size();
     AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = sinh((*this)[i]);}
 
     return temp;
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::cosh() const{
-/*! Compute the hyperbolic cosine of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::cosh() const {
+/*! Element-wise application of the hyperbolic cosine function.
    \return A new AlgebraicVector<T>.
  */
     using std::cosh;
 
     const size_t size = this->size();
     AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = cosh((*this)[i]);}
 
     return temp;
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::tanh() const{
-/*! Compute the hyperbolic tangent of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::tanh() const {
+/*! Element-wise application of the hyperbolic tangent function.
    \return A new AlgebraicVector<T>.
  */
     using std::tanh;
 
     const size_t size = this->size();
     AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = tanh((*this)[i]);}
 
     return temp;
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::logb(const double b) const{
-/*! Compute the logarithm of a AlgebraicVector<T> with respect to a given base.
-    The result is copied in a new AlgebraicVector<T>.
-   \param[in] b base with respect to which the logarithm is computed (default = 10).
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::asinh() const {
+/*! Element-wise application of the hyperbolic arcsine function.
    \return A new AlgebraicVector<T>.
  */
-    using DACE::logb;
+    using std::asinh;
 
     const size_t size = this->size();
     AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
-        temp[i] = logb((*this)[i], b);}
-
-    return temp;
-}
-
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::isrt() const{
-/*! Compute the inverse square root of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
-   \return A new AlgebraicVector<T>.
- */
-    using DACE::isrt;
-
-    const size_t size = this->size();
-    AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
-        temp[i] = isrt((*this)[i]);}
-
-    return temp;
-}
-
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::sqr() const{
-/*! Compute the square of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
-   \return A new AlgebraicVector<T>.
- */
-    using DACE::sqr;
-
-    const size_t size = this->size();
-    AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
-        temp[i] = sqr((*this)[i]);}
-
-    return temp;
-}
-
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::minv() const{
-/*! Compute the multiplicative inverse of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
-   \return A new AlgebraicVector<T>.
- */
-    using DACE::minv;
-
-    const size_t size = this->size();
-    AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
-        temp[i] = minv((*this)[i]);}
-
-    return temp;
-}
-
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::root(const int p) const{
-/*! Compute the p-th root of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
-   \param[in] p root to be computed (default = 2).
-   \return A new AlgebraicVector<T>.
- */
-    using DACE::root;
-
-    const size_t size = this->size();
-    AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
-        temp[i] = root((*this)[i],p);}
-
-    return temp;
-}
-
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::asinh() const{
-/*! Compute the hyperbolic arcsine of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
- */
-    using DACE::asinh;
-
-    const size_t size = this->size();
-    AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = asinh((*this)[i]);}
 
     return temp;
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::acosh() const{
-/*! Compute the hyperbolic arccosine of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>. Currently not defined for double.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::acosh() const {
+/*! Element-wise application of the hyperbolic arccosine function.
+   \return A new AlgebraicVector<T>.
  */
-    using DACE::acosh;
+    using std::acosh;
 
     const size_t size = this->size();
     AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = acosh((*this)[i]);}
 
     return temp;
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::atanh() const{
-/*! Compute the hyperbolic arctangent of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.  Currently not defined for double.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::atanh() const {
+/*! Element-wise application of the hyperbolic arctangent function.
+   \return A new AlgebraicVector<T>.
  */
-    using DACE::atanh;
+    using std::atanh;
 
     const size_t size = this->size();
     AlgebraicVector<T> temp(size);
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         temp[i] = atanh((*this)[i]);}
 
     return temp;
@@ -821,39 +939,36 @@ template<typename T> AlgebraicVector<T> AlgebraicVector<T>::atanh() const{
 /***********************************************************************************
 *    Vector norm routines
 ************************************************************************************/
-template<typename T> T AlgebraicVector<T>::vnorm() const{
-/*! Compute the Euclidean vector norm (length) for a AlgebraicVector<T>.
-   \return A scalar value corresponding to the result of the operation.
+template<typename T> T AlgebraicVector<T>::length() const {
+/*! Compute the length (Euclidean vector norm).
+   \return Length of the vector.
  */
     using std::sqrt; using DACE::sqr;      // Implementational note: these using statements are very subtle and absolutely needed.
                                             // They force the compiler to perform argument dependent lookup (ADL) which then finds
-                                            // the correct root() and pow() functions even if they are not in DACE:: or std::!
+                                            // the correct sqrt() and sqr() functions even if they are not in DACE:: or std::!
     const size_t size = this->size();
     T norm = 0.0;
-    for(size_t i=0; i<size; i++){
+    for(size_t i=0; i<size; i++) {
         norm = norm + sqr((*this)[i]);}
 
     return sqrt(norm);
 }
 
-template<typename T> AlgebraicVector<T> AlgebraicVector<T>::normalize() const{
+template<typename T> AlgebraicVector<T> AlgebraicVector<T>::normalize() const {
 /*! Normalize the vector.
    \return An AlgebraicVector<T> of unit length.
  */
-    const size_t size = this->size();
-    AlgebraicVector<T> temp(size);
-    T norm = 1.0/this->vnorm();
+    using DACE::minv;
 
-    for(size_t i=0; i<size; i++){
-        temp[i] = (*this)[i]*norm;}
-
+    AlgebraicVector<T> temp(*this);
+    temp *= minv(this->length());
     return temp;
 }
 
 /***********************************************************************************
 *     Polynomial evaluation routines
 ************************************************************************************/
-template<> template<typename V> V AlgebraicVector<DA>::eval(const V &args) const{
+template<> template<typename V> V AlgebraicVector<DA>::eval(const V &args) const {
 /*! Evaluate a vector of polynomials with any vector type V with arguments
     and return a vector of results of the same type V.
    \param[in] args vector (e.g. AlgebraicVector<>) of arguments
@@ -867,7 +982,7 @@ template<> template<typename V> V AlgebraicVector<DA>::eval(const V &args) const
     return compiledDA(*this).eval(args);
 }
 
-template<> template<typename U> AlgebraicVector<U> AlgebraicVector<DA>::eval(const std::initializer_list<U> l) const{
+template<> template<typename U> AlgebraicVector<U> AlgebraicVector<DA>::eval(const std::initializer_list<U> l) const {
 /*! Evaluate a vector of polynomials with an braced initializer list of type U
     and return an AlgebraicVector of type U with the results.
    \param[in] l Braced initializer list containing the arguments.
@@ -879,7 +994,7 @@ template<> template<typename U> AlgebraicVector<U> AlgebraicVector<DA>::eval(con
     return compiledDA(*this).eval<U>(l);
 }
 
-template<> template<typename U> AlgebraicVector<U> AlgebraicVector<DA>::evalScalar(const U &arg) const{
+template<> template<typename U> AlgebraicVector<U> AlgebraicVector<DA>::evalScalar(const U &arg) const {
 /*! Evaluate a vector of polynomials with a single arithmetic type U argument.
    \param[in] arg single variable of arithmetic type T of the first independent DA variable.
    \return The result of the evaluation.
@@ -898,7 +1013,7 @@ template<> template<typename U> AlgebraicVector<U> AlgebraicVector<DA>::evalScal
 /***********************************************************************************
 *     Input/Output routines
 ************************************************************************************/
-template<typename U> std::ostream& operator<<(std::ostream &out, const AlgebraicVector<U> &obj){
+template<typename U> std::ostream& operator<<(std::ostream &out, const AlgebraicVector<U> &obj) {
 /*! Output a vector to a C++ output stream.
    \param[in] out standard output stream.
    \param[in] obj AlgebraicVector<U> to be written to the stream
@@ -907,15 +1022,15 @@ template<typename U> std::ostream& operator<<(std::ostream &out, const Algebraic
     const size_t size = obj.size();
 
     out << "[[[ " << size << " vector" << std::endl;
-    for(size_t i=0; i<size;i++){
+    for(size_t i=0; i<size;i++) {
         out << obj[i] << std::endl;}
     out << "]]]" << std::endl;
 
     return out;
 }
 
-template<typename U> std::istream& operator>>(std::istream &in, AlgebraicVector<U> &obj){
-/*! Input a vector from a C++ input stream.
+template<typename U> std::istream& operator>>(std::istream &in, AlgebraicVector<U> &obj) {
+/*! Read a vector from a C++ input stream.
    \param[in] in standard input stream.
    \param[in] obj AlgebraicVector<U> to be read from the stream
    \return Reference to input stream in.
@@ -925,7 +1040,7 @@ template<typename U> std::istream& operator>>(std::istream &in, AlgebraicVector<
 
     // try to read the first line
     getline(in, init_line);
-    if(in.good()){
+    if(in.good()) {
         // retrieve the size of the vector to be read
         std::size_t found = init_line.find_first_of(' ');
         std::string size_str(init_line,4,found-4);
@@ -950,8 +1065,8 @@ template<typename U> std::istream& operator>>(std::istream &in, AlgebraicVector<
     return in;
 }
 
-template<typename T> std::string AlgebraicVector<T>::toString() const{
-/*! Convert the current AlgebraicVector<T> to string.
+template<typename T> std::string AlgebraicVector<T>::toString() const {
+/*! Convert to string.
     \return A string.
  */
     std::ostringstream strs;
@@ -963,266 +1078,335 @@ template<typename T> std::string AlgebraicVector<T>::toString() const{
 /***********************************************************************************
 *     Non-member functions
 ************************************************************************************/
-template<typename T> AlgebraicVector<double> cons(const AlgebraicVector<T> &obj){
-/*! Return the constant part of a AlgebraicVector<T>.
+template<typename T> AlgebraicVector<double> cons(const AlgebraicVector<T> &obj) {
+/*! Return the constant parts.
    \return An AlgebraicVector<double>.
    \sa AlgebraicVector<T>::cons
  */
     return obj.cons();
 }
 
-template<typename T> AlgebraicVector<T> pow(const AlgebraicVector<T> &obj, const int p){
-/*! Elevate a AlgebraicVector<T> to a given integer power.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> absolute(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the absolute value function.
    \param[in] obj AlgebraicVector<T>.
-   \param[in] p power at which the AlgebraicVector is elevated.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
+   \sa AlgebraicVector<T>::absolute
+ */
+    return obj.absolute();
+}
+
+template<typename T> AlgebraicVector<T> trunc(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the truncation function.
+   \param[in] obj AlgebraicVector<T>.
+   \return A new AlgebraicVector<T>.
+   \sa AlgebraicVector<T>::trunc
+ */
+    return obj.trunc();
+}
+
+template<typename T> AlgebraicVector<T> round(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the round function.
+   \param[in] obj AlgebraicVector<T>.
+   \return A new AlgebraicVector<T>.
+   \sa AlgebraicVector<T>::round
+ */
+    return obj.round();
+}
+
+template<typename T> AlgebraicVector<T> mod(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the mod function.
+   \param[in] obj AlgebraicVector<T>.
+   \return A new AlgebraicVector<T>.
+   \sa AlgebraicVector<T>::mod
+ */
+    return obj.mod();
+}
+
+template<typename T> AlgebraicVector<T> pow(const AlgebraicVector<T> &obj, const int p) {
+/*! Element-wise application of the integer power function.
+   \param[in] obj AlgebraicVector<T>.
+   \param[in] p power to raise each element to.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::pow
  */
     return obj.pow(p);
 }
 
-template<typename T> AlgebraicVector<T> root(const AlgebraicVector<T> &obj, const int p){
-/*! Compute the p-th root of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> pow(const AlgebraicVector<T> &obj, const double p) {
+/*! Element-wise application of the double power function.
    \param[in] obj AlgebraicVector<T>.
-   \param[in] p root to be computed (default = 2).
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \param[in] p power to raise each element to.
+   \return A new AlgebraicVector<T>.
+   \sa AlgebraicVector<T>::pow
+ */
+    return obj.pow(p);
+}
+
+template<typename T> AlgebraicVector<T> root(const AlgebraicVector<T> &obj, const int p) {
+/*! Element-wise application of the root function.
+   \param[in] obj AlgebraicVector<T>.
+   \param[in] p root to be computed.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::root
  */
     return obj.root(p);
 }
 
-template<typename T> AlgebraicVector<T> minv(const AlgebraicVector<T> &obj){
-/*! Compute the multiplicative inverse of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> minv(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the multiplicative inverse function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::minv
  */
     return obj.minv();
 }
 
-template<typename T> AlgebraicVector<T> sqr(const AlgebraicVector<T> &obj){
-/*! Compute the square of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> sqr(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the square function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::sqr
  */
     return obj.sqr();
 }
 
-template<typename T> AlgebraicVector<T> sqrt(const AlgebraicVector<T> &obj){
-/*! Compute the square root of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> sqrt(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the square root function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::sqrt
  */
     return obj.sqrt();
 }
 
-template<typename T> AlgebraicVector<T> isrt(const AlgebraicVector<T> &obj){
-/*! Compute the inverse square root of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> isrt(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the inverse square root function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::isrt
  */
     return obj.isrt();
 }
 
-template<typename T> AlgebraicVector<T> exp(const AlgebraicVector<T> &obj){
-/*! Compute the exponential of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> cbrt(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the cube root function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
+   \sa AlgebraicVector<T>::cbrt
+ */
+    return obj.cbrt();
+}
+
+template<typename T> AlgebraicVector<T> icbrt(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the inverse cube root function.
+   \param[in] obj AlgebraicVector<T>.
+   \return A new AlgebraicVector<T>.
+   \sa AlgebraicVector<T>::icbrt
+ */
+    return obj.icbrt();
+}
+
+template<typename T> AlgebraicVector<T> hypot(const AlgebraicVector<T> &X, const AlgebraicVector<T> &Y) {
+/*! Element-wise application of the hypotenuse function.
+   \param[in] X AlgebraicVector<T> containing X.
+   \param[in] Y AlgebraicVector<T> containing Y.
+   \return A new AlgebraicVector<T>.
+   \sa AlgebraicVector<T>::hypot
+ */
+    return X.hypot(Y);
+}
+
+template<typename T> AlgebraicVector<T> exp(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the exponential function.
+   \param[in] obj AlgebraicVector<T>.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::exp
  */
     return obj.exp();
 }
 
-template<typename T> AlgebraicVector<T> log(const AlgebraicVector<T> &obj){
-/*! Compute the natural logarithm of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> log(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the natural logarithm function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::log
  */
     return obj.log();
 }
 
-template<typename T> AlgebraicVector<T> logb(const AlgebraicVector<T> &obj, const double b){
-/*! Compute the logarithm of a AlgebraicVector<T> with respect to a given base.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> logb(const AlgebraicVector<T> &obj, const double b) {
+/*! Element-wise application of the logarithm function relative to given base.
    \param[in] obj AlgebraicVector<T>.
-   \param[in] b base with respect to which the logarithm is computed (default = 10).
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \param[in] b base for the logarithm
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::logb
  */
     return obj.logb(b);
 }
 
-template<typename T> AlgebraicVector<T> sin(const AlgebraicVector<T> &obj){
-/*! Compute the sine of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> log10(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the decadic logarithm function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
+   \sa AlgebraicVector<T>::log10
+ */
+    return obj.log10();
+}
+
+template<typename T> AlgebraicVector<T> log2(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the binary logarithm function.
+   \param[in] obj AlgebraicVector<T>.
+   \return A new AlgebraicVector<T>.
+   \sa AlgebraicVector<T>::log2
+ */
+    return obj.log2();
+}
+
+template<typename T> AlgebraicVector<T> sin(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the sine function.
+   \param[in] obj AlgebraicVector<T>.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::sin
  */
     return obj.sin();
 }
 
-template<typename T> AlgebraicVector<T> cos(const AlgebraicVector<T> &obj){
-/*! Compute the cosine of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> cos(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the cosine function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::cos
  */
     return obj.cos();
 }
 
-template<typename T> AlgebraicVector<T> tan(const AlgebraicVector<T> &obj){
-/*! Compute the tangent of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> tan(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the tangent function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::tan
  */
     return obj.tan();
 }
 
-template<typename T> AlgebraicVector<T> asin(const AlgebraicVector<T> &obj){
-/*! Compute the arcsine of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> asin(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the arcsine function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::asin
  */
     return obj.asin();
 }
 
-template<typename T> AlgebraicVector<T> acos(const AlgebraicVector<T> &obj){
-/*! Compute the arccosine of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> acos(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the arccosine function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::acos
  */
     return obj.acos();
 }
 
-template<typename T> AlgebraicVector<T> atan(const AlgebraicVector<T> &obj){
-/*! Compute the arctangent of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> atan(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the arctangent function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::atan
  */
     return obj.atan();
 }
 
-template<typename T> AlgebraicVector<T> atan2(const AlgebraicVector<T> &obj1, const AlgebraicVector<T> &obj2){
-/*! Compute the four-quadrant tangent of obj1/obj2.
-    The result is copied in a new AlgebraicVector<T>.
-   \param[in] obj1 AlgebraicVector<T>.
-   \param[in] obj2 AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation in [-pi, pi].
+template<typename T> AlgebraicVector<T> atan2(const AlgebraicVector<T> &Y, const AlgebraicVector<T> &X) {
+/*! Element-wise application of the four-quadrant arctangent of Y/X.
+   \param[in] Y AlgebraicVector<T> containing Y.
+   \param[in] X AlgebraicVector<T> containing X.
+   \return A new AlgebraicVector<T> with elements in [-pi, pi].
    \sa AlgebraicVector<T>::atan2
  */
-    return obj1.atan(obj2);
+    return Y.atan2(X);
 }
 
-template<typename T> AlgebraicVector<T> sinh(const AlgebraicVector<T> &obj){
-/*! Compute the hyperbolic sine of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> sinh(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the hyperbolic sine function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::sinh
  */
     return obj.sinh();
 }
 
-template<typename T> AlgebraicVector<T> cosh(const AlgebraicVector<T> &obj){
-/*! Compute the hyperbolic cosine of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> cosh(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the hyperbolic cosine function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::cosh
  */
     return obj.cosh();
 }
 
-template<typename T> AlgebraicVector<T> tanh(const AlgebraicVector<T> &obj){
-/*! Compute the hyperbolic tangent of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> tanh(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the hyperbolic tangent function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::tanh
  */
     return obj.tanh();
 }
 
-template<typename T> AlgebraicVector<T> asinh(const AlgebraicVector<T> &obj){
-/*! Compute the hyperbolic arcsine of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> asinh(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the hyperbolic arcsine function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::asinh
  */
     return obj.asinh();
 }
 
-template<typename T> AlgebraicVector<T> acosh(const AlgebraicVector<T> &obj){
-/*! Compute the hyperbolic arccosine of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> acosh(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the hyperbolic arccosine function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::acosh
  */
     return obj.acosh();
 }
 
-template<typename T> AlgebraicVector<T> atanh(const AlgebraicVector<T> &obj){
-/*! Compute the hyperbolic arctangent of a AlgebraicVector<T>.
-    The result is copied in a new AlgebraicVector<T>.
+template<typename T> AlgebraicVector<T> atanh(const AlgebraicVector<T> &obj) {
+/*! Element-wise application of the hyperbolic arctangent function.
    \param[in] obj AlgebraicVector<T>.
-   \return A new AlgebraicVector<T> containing the result of the operation.
+   \return A new AlgebraicVector<T>.
    \sa AlgebraicVector<T>::atanh
  */
     return obj.atanh();
 }
 
-template<typename U, typename V> typename PromotionTrait<U,V>::returnType dot(const AlgebraicVector<U> &obj1, const AlgebraicVector<V> &obj2){
+template<typename U, typename V> typename PromotionTrait<U,V>::returnType dot(const AlgebraicVector<U> &obj1, const AlgebraicVector<V> &obj2) {
 /*! Compute the dot product between two AlgebraicVectors.
    \param[in] obj1 a AlgebraicVector.
    \param[in] obj2 a AlgebraicVector.
-   \return A scalar value, containing the result of the operation.
+   \return A scalar value,.
  */
     return obj1.dot(obj2);
 }
 
-template<typename U, typename V> AlgebraicVector<typename PromotionTrait<U,V>::returnType> cross(const AlgebraicVector<U> &obj1, const AlgebraicVector<V> &obj2){
+template<typename U, typename V> AlgebraicVector<typename PromotionTrait<U,V>::returnType> cross(const AlgebraicVector<U> &obj1, const AlgebraicVector<V> &obj2) {
 /*! Compute the cross product between two 3D AlgebraicVectors.
    \param[in] obj1 a AlgebraicVector.
    \param[in] obj2 a AlgebraicVector.
-   \return A new AlgebraicVector, containing the result of the operation.
+   \return A new AlgebraicVector,.
  */
     return obj1.cross(obj2);
 }
 
-template<typename T> T vnorm(const AlgebraicVector<T> &obj){
-/*! Compute the Euclidean vector norm (length) of an AlgebraicVector<T>.
+template<typename T> T length(const AlgebraicVector<T> &obj) {
+/*! Compute the length (Euclidean vector norm).
    \param[in] obj AlgebraicVector<T>.
-   \return A scalar value containing the result of the operation.
-   \sa AlgebraicVector<T>::norm
+   \return Length of the vector.
  */
-    return obj.vnorm();
+    return obj.length();
 }
 
-template<typename T> AlgebraicVector<T> normalize(const AlgebraicVector<T> &obj){
+template<typename T> AlgebraicVector<T> normalize(const AlgebraicVector<T> &obj) {
 /*! Normalize an AlgebraicVector<T>.
    \param[in] obj An AlgebraicVector<T> to normalize.
    \return An AlgebraicVector<T> of unit length.
@@ -1231,7 +1415,7 @@ template<typename T> AlgebraicVector<T> normalize(const AlgebraicVector<T> &obj)
     return obj.normalize();
 }
 
-template<typename V> V eval(const AlgebraicVector<DA> &obj, const V &args){
+template<typename V> V eval(const AlgebraicVector<DA> &obj, const V &args) {
 /*! Evaluate an AlgebraicVector<DA> with a vector type V of arguments
     and return a vector of type V with the results.
    \param[in] obj An AlgebraicVector<DA>.
@@ -1242,7 +1426,7 @@ template<typename V> V eval(const AlgebraicVector<DA> &obj, const V &args){
     return obj.eval(args);
 }
 
-template<typename T> AlgebraicVector<T> eval(const AlgebraicVector<DA> &obj, const std::initializer_list<T> l){
+template<typename T> AlgebraicVector<T> eval(const AlgebraicVector<DA> &obj, const std::initializer_list<T> l) {
 /*! Evaluate an AlgebraicVector<DA> with an braced initializer list of type T
     and return an AlgebraicVector of type T with the results.
    \param[in] obj An AlgebraicVector<DA>.
@@ -1256,7 +1440,7 @@ template<typename T> AlgebraicVector<T> eval(const AlgebraicVector<DA> &obj, con
     return obj.eval<T>(l);
 }
 
-template<typename U> AlgebraicVector<U> evalScalar(const AlgebraicVector<DA> &obj, const U &arg){
+template<typename U> AlgebraicVector<U> evalScalar(const AlgebraicVector<DA> &obj, const U &arg) {
 /*! Evaluate an AlgebraicVector<DA> with a single scalar argument of type U
     and return an AlgebraicVector<U> containing the results.
    \param[in] obj The AlgebraicVector<T> to evaluate.

--- a/interfaces/cxx/include/dace/DA.h
+++ b/interfaces/cxx/include/dace/DA.h
@@ -65,6 +65,8 @@ private:
     DACEDA m_index;                                                         //!< Index to the DA vector
 
 public:
+   typedef double value_type;                                               //!< Underlying type of DA coefficients (for compatibility with C++ std lib, boost, etc)
+
     /********************************************************************************
     *     DACE Setup
     *********************************************************************************/
@@ -99,15 +101,15 @@ public:
     /********************************************************************************
     *     Coefficient access and extraction routines
     *********************************************************************************/
-    int isnan() const;
-    int isinf() const;
+    int isnan() const;                                                      //!< Check if any coefficients are NaNs
+    int isinf() const;                                                      //!< Check if any coefficients are Inf
     double cons() const;                                                    //!< Get constant part of a DA
     AlgebraicVector<double> linear() const;                                 //!< Get linear part of a DA
     AlgebraicVector<DA> gradient() const;                                   //!< Gradient vector with respect to all independent DA variables
     double getCoefficient(const std::vector<unsigned int> &jj) const;                //!< Get specific coefficient
     void setCoefficient(const std::vector<unsigned int> &jj, const double coeff);    //!< Set specific coefficient
     Monomial getMonomial(const unsigned int npos) const;                    //!< Get the Monomial at given position
-    void getMonomial(const unsigned int npos, Monomial &m) const;            //!< Extract the Monomial at given position
+    void getMonomial(const unsigned int npos, Monomial &m) const;           //!< Extract the Monomial at given position
     std::vector<Monomial> getMonomials() const;                             //!< Get std::vector of all non-zero Monomials
 
     /********************************************************************************
@@ -208,7 +210,6 @@ public:
     *    Norm and estimation routines
     *********************************************************************************/
     unsigned int size() const;                                              //!< Number of non-zero coefficients
-    double abs() const;                                                     //!< Maximum absolute value of all coefficients
     double norm(const unsigned int type = 0) const;                         //!< Different types of norms over all coefficients
     std::vector<double> orderNorm(const unsigned int var = 0, const unsigned int type = 0) const;
                                                                             //!< Different types of norms over coefficients of each order separately
@@ -320,7 +321,6 @@ DACE_API DA LogGammaFunction(const DA &da);
 DACE_API DA PsiFunction(const unsigned int n, const DA &da);
 
 DACE_API unsigned int size(const DA &da);
-DACE_API double abs(const DA &da);
 DACE_API double norm(const DA &da, unsigned int type = 0);
 DACE_API std::vector<double> orderNorm(const DA &da, unsigned int var = 0, unsigned int type = 0);
 DACE_API std::vector<double> estimNorm(const DA &da, unsigned int var = 0, unsigned int type = 0, unsigned int nc = DA::getMaxOrder());
@@ -340,6 +340,17 @@ DACE_API DA translateVariable(const DA &da, const unsigned int var = 0, const do
 DACE_API std::string toString(const DA &da);
 DACE_API void write(const DA &da, std::ostream &os);
 
+namespace abs_cons {
+    double abs(const DA &da);                       //!< Absolute value of constant part.
+}
+
+namespace abs_max {
+    double abs(const DA &da);                       //!< Largest coefficient in absolute value.
+}
+
+namespace abs_sum {
+    double abs(const DA &da);                       //!< Sum of absolute values of all coefficients.
+}
 
 
 /*! Stored DA class representing a DA vector in a binary, setup independent format. */
@@ -349,7 +360,7 @@ private:
     static const unsigned int headerSize;
 
 public:
-    storedDA(const DA &da);                            //!< Constructor from a DA.
+    storedDA(const DA &da);                         //!< Constructor from a DA.
     storedDA(const std::vector<char> &data);        //!< Constructor from binary data.
     storedDA(std::istream &is);                     //!< Constructor from stream.
 

--- a/interfaces/cxx/include/dace/DA.h
+++ b/interfaces/cxx/include/dace/DA.h
@@ -162,6 +162,7 @@ public:
     DA integ(const std::vector<unsigned int> ind) const;                    //!< Integral with respect to given variables
     DA trim(const unsigned int min, const unsigned int max = DA::getMaxOrder()) const;
                                                                             //!< Trim the coefficients only include orders between min and max, inclusively
+    DA absolute() const;                                                    //!< Absolute value of DA based on constant part
     DA trunc() const;                                                       //!< Truncate the constant part to an integer
     DA round() const;                                                       //!< Round the constant part to an integer
     DA mod(const double p) const;                                           //!< Modulo of the constant part
@@ -272,6 +273,7 @@ DACE_API DA deriv(const DA &da, const std::vector<unsigned int> ind);
 DACE_API DA integ(const DA &da, const unsigned int i);
 DACE_API DA integ(const DA &da, const std::vector<unsigned int> ind);
 DACE_API DA trim(const DA &da, const unsigned int min, const unsigned int max = DA::getMaxOrder());
+DACE_API DA absolute(const DA &da);
 DACE_API DA trunc(const DA &da);
 DACE_API DA round(const DA &da);
 DACE_API DA mod(const DA &da, const double p);

--- a/interfaces/cxx/include/dace/MathExtension.h
+++ b/interfaces/cxx/include/dace/MathExtension.h
@@ -39,6 +39,7 @@ DACE_API double icbrt(const double x);                           //!< Inverse cu
 DACE_API double sqr(const double x);                             //!< Square
 DACE_API double minv(const double x);                            //!< Multiplicative inverse
 DACE_API double root(const double x, const int p = 2);           //!< p-th root
+DACE_API double norm(const double x, const int type = 0);        //!< norm (same as abs)
 
 }
 

--- a/interfaces/cxx/include/dace/MathExtension.h
+++ b/interfaces/cxx/include/dace/MathExtension.h
@@ -31,6 +31,7 @@
 
 namespace DACE{
 
+DACE_API double absolute(const double x);                        //!< Absolute value
 DACE_API double cons(const double x);                            //!< Constant part (i.e. the value x)
 DACE_API double logb(const double x, const double b = 10.0);     //!< Logarithm relative to base b
 DACE_API double isrt(const double x);                            //!< Inverse square root

--- a/interfaces/cxx/include/dace/MathExtension.h
+++ b/interfaces/cxx/include/dace/MathExtension.h
@@ -35,6 +35,7 @@ DACE_API double absolute(const double x);                        //!< Absolute v
 DACE_API double cons(const double x);                            //!< Constant part (i.e. the value x)
 DACE_API double logb(const double x, const double b = 10.0);     //!< Logarithm relative to base b
 DACE_API double isrt(const double x);                            //!< Inverse square root
+DACE_API double icbrt(const double x);                           //!< Inverse cube root
 DACE_API double sqr(const double x);                             //!< Square
 DACE_API double minv(const double x);                            //!< Multiplicative inverse
 DACE_API double root(const double x, const int p = 2);           //!< p-th root

--- a/interfaces/cxx/include/dace/compat_boost_odeint.h
+++ b/interfaces/cxx/include/dace/compat_boost_odeint.h
@@ -1,0 +1,74 @@
+/******************************************************************************
+*                                                                             *
+* DIFFERENTIAL ALGEBRA CORE ENGINE                                            *
+*                                                                             *
+*******************************************************************************
+*                                                                             *
+* Copyright 2025 Alexander Wittig                                             *
+* Licensed under the Apache License, Version 2.0 (the "License");             *
+* you may not use this file except in compliance with the License.            *
+* You may obtain a copy of the License at                                     *
+*                                                                             *
+*    http://www.apache.org/licenses/LICENSE-2.0                               *
+*                                                                             *
+* Unless required by applicable law or agreed to in writing, software         *
+* distributed under the License is distributed on an "AS IS" BASIS,           *
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    *
+* See the License for the specific language governing permissions and         *
+* limitations under the License.                                              *
+*                                                                             *
+*******************************************************************************/
+
+/*
+ * compat_boost_odeint.h
+ *
+ *  Created on: Apr 25, 2025
+ *      Author: Alexander Wittig
+ */
+
+#ifndef DINAMICA_COMPAT_BOOST_ODEINT_H_
+#define DINAMICA_COMPAT_BOOST_ODEINT_H_
+
+/*! This file needs to be included after boost/numeric/odeint.hpp and dace/dace.h to provide
+    a compatibility shim to allow odeint to work with DACE::AlgebraicVector<> as a state type.
+    It can be used both with DA and double data types.
+
+    Additionally, after including this file, an implementation of abs(DACE::DA) must be provided
+    within the DACE namespace.
+    For most practical uses, this can be done by selecting one of the predefined implementations
+    provided in DACE::abs_cons, DACE::abs_max, or DACE::abs_sum.
+
+    Example:
+    \code
+        #include <boost/numeric/odeint.hpp>
+        #include <dace/dace.h>
+        #include <dace/compat_boost_odeint.h>
+
+        // select implementation of abs(DA)
+        namespace DACE { using DACE::abs_max::abs; }
+
+
+        using namespace boost::numeric::odeint;
+        using namespace DACE;
+
+        // define RHS, call DA::init, ...
+
+        typedef state_type AlgebraicVector<DA>;
+
+        state_type x(3);
+        x[0] = 1.0; x[1] = 2.0; x[3] = 3.0;
+        x += 0.01 * x.identity(3);
+        integrate_adaptive( make_controlled( 1e-8, 1e-8, runge_kutta_dopri5<state_type>() ), RHS, x, 0.0, 10.0, 0.1 );
+    \endcode
+ */
+
+ namespace boost { namespace numeric { namespace odeint {
+    // mark AlgebraicVectors as resizable (using the standard container interface inherited from std::vector)
+    template<typename T> struct is_resizeable<DACE::AlgebraicVector<T>>
+    {
+        typedef boost::true_type type;
+        static const bool value = type::value;
+    };
+} } }
+
+#endif /* DINAMICA_COMPAT_BOOST_ODEINT_H_ */


### PR DESCRIPTION
API breaking changes:
daceAbsoluteValue() removal from core.
abs() removal from DACE::DA.
rename AlgebraicVector::vnorm -> AlgebraicVector::length

Additions:
daceAbsolute() to core
absolute() value function to DACE::DA and DACE::AlgebraicVector
Different non-member abs() implementations now in DACE::abs_cons, DACE::abs_max, DACE::abs_sum namespaces
compat_boost_odeint.h compatibility header for boost::odeint
Expose most DACE::DA functions as componentwise operations to DACE::AlgebraicVector (including norm())

Non-functional changes:
some white space cleanup
some documentation updates